### PR TITLE
use resource loader to support classpath and file system files #66

### DIFF
--- a/spring-cloud-azure-context/src/main/java/com/microsoft/azure/spring/cloud/context/core/DefaultCredentialsProvider.java
+++ b/spring-cloud-azure-context/src/main/java/com/microsoft/azure/spring/cloud/context/core/DefaultCredentialsProvider.java
@@ -10,7 +10,7 @@ import com.google.common.base.Strings;
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.DefaultResourceLoader;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +34,8 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
     private void initCredentials(CredentialSupplier supplier) {
         if (!Strings.isNullOrEmpty(supplier.getCredentialFilePath())) {
             try {
-                File credentialFile = new ClassPathResource(supplier.getCredentialFilePath()).getFile();
+                DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
+                File credentialFile = resourceLoader.getResource(supplier.getCredentialFilePath()).getFile();
                 this.credentials = ApplicationTokenCredentials.fromFile(credentialFile);
             } catch (IOException e) {
                 LOGGER.error("Credential file path not found.", e);


### PR DESCRIPTION
Issue #66 

## Description
Allow user to configure loading credential file from both classpath and file system.

e.g.,
1. If load credential file from classpath src/main/resources/my.auth, use `classpath:my.auth`
2. If load credential file from file system C:/Users/me/.azure/my.auth, use `file:C:/Users/me/.azure/my.auth`

