### PR TITLE
Remove resourceGroup from telemetry data, fix #106.

### DIFF
--- a/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/telemetry/TelemetryAutoConfiguration.java
+++ b/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/telemetry/TelemetryAutoConfiguration.java
@@ -6,11 +6,9 @@
 
 package com.microsoft.azure.spring.cloud.autoconfigure.telemetry;
 
-
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.spring.cloud.autoconfigure.context.AzureContextAutoConfiguration;
-import com.microsoft.azure.spring.cloud.autoconfigure.context.AzureProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -32,11 +30,10 @@ public class TelemetryAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(name = "telemetry.instrumentationKey")
-    public TelemetryTracker telemetryTracker(Azure azure, AzureProperties azureProperties,
-            TelemetryProperties telemetryProperties) {
+    public TelemetryTracker telemetryTracker(Azure azure, TelemetryProperties telemetryProperties) {
         try {
             return new TelemetryTracker(azure.getCurrentSubscription().subscriptionId(),
-                    azureProperties.getResourceGroup(), telemetryProperties.getInstrumentationKey());
+                    telemetryProperties.getInstrumentationKey());
         } catch (IllegalArgumentException e) {
             LOG.warn("Invalid argument to build telemetry tracker");
             return null;

--- a/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/telemetry/TelemetryTracker.java
+++ b/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/telemetry/TelemetryTracker.java
@@ -28,8 +28,6 @@ public class TelemetryTracker {
 
     private static final String PROPERTY_SUBSCRIPTION_ID = "subscriptionId";
 
-    private static final String PROPERTY_RESOURCE_GROUP = "resourceGroup";
-
     private static final String PROPERTY_SERVICE_NAME = "serviceName";
 
     private static final String SPRING_CLOUD_AZURE_EVENT = "spring-cloud-azure";
@@ -42,8 +40,8 @@ public class TelemetryTracker {
 
     private final Map<String, String> defaultProperties;
 
-    public TelemetryTracker(@NonNull String subscriptionId, @NonNull String resourceGroup, String instrumentationKey) {
-        this.defaultProperties = buildDefaultProperties(subscriptionId, resourceGroup);
+    public TelemetryTracker(@NonNull String subscriptionId, String instrumentationKey) {
+        this.defaultProperties = buildDefaultProperties(subscriptionId);
         this.client = buildTelemetryClient(instrumentationKey);
     }
 
@@ -53,11 +51,10 @@ public class TelemetryTracker {
         }
     }
 
-    private Map<String, String> buildDefaultProperties(String subscriptionId, String resourceGroup) {
+    private Map<String, String> buildDefaultProperties(String subscriptionId) {
         Map<String, String> properties = new HashMap<>();
 
         properties.put(PROPERTY_SUBSCRIPTION_ID, subscriptionId);
-        properties.put(PROPERTY_RESOURCE_GROUP, resourceGroup);
         properties.put(PROPERTY_VERSION, PROJECT_INFO);
         properties.put(PROPERTY_INSTALLATION_ID, MacAddressHelper.getHashedMacAddress());
 


### PR DESCRIPTION
## Description
Remove resourceGroup from telemetry data, as it from user created and GDPR in-scope.

## Steps to Test
Steps to test code change
