### PR TITLE
GH-279 Remove unused imports and add generic specifications

### DIFF
--- a/spring-cloud-azure-eventhub-stream-binder/src/test/java/com/microsoft/azure/eventhub/stream/binder/EventHubPartitionBinderTests.java
+++ b/spring-cloud-azure-eventhub-stream-binder/src/test/java/com/microsoft/azure/eventhub/stream/binder/EventHubPartitionBinderTests.java
@@ -144,7 +144,7 @@ public class EventHubPartitionBinderTests extends
         // moduleOutputChannel.send(message);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Message<byte[]>> inboundMessageRef = new AtomicReference();
+        final AtomicReference<Message<byte[]>> inboundMessageRef = new AtomicReference<>();
         moduleInputChannel.subscribe(message1 -> {
             try {
                 inboundMessageRef.set((Message<byte[]>) message1);
@@ -157,7 +157,7 @@ public class EventHubPartitionBinderTests extends
         Assert.isTrue(latch.await(5L, TimeUnit.SECONDS), "Failed to receive message");
         Assertions.assertThat(inboundMessageRef.get()).isNotNull();
         Assertions.assertThat(
-                new String((byte[]) ((Message) inboundMessageRef.get()).getPayload(), StandardCharsets.UTF_8))
+                new String(((Message<byte[]>) inboundMessageRef.get()).getPayload(), StandardCharsets.UTF_8))
                   .isEqualTo("foo");
         Assertions.assertThat(inboundMessageRef.get().getHeaders().get("contentType").toString())
                   .isEqualTo("text/plain");

--- a/spring-cloud-azure-samples/spring-cloud-azure-eventhub-binder-sample/src/main/java/com/example/SourceExample.java
+++ b/spring-cloud-azure-samples/spring-cloud-azure-eventhub-binder-sample/src/main/java/com/example/SourceExample.java
@@ -11,7 +11,6 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/spring-cloud-azure-samples/spring-cloud-azure-eventhub-integration-sample/src/main/java/example/SendController.java
+++ b/spring-cloud-azure-samples/spring-cloud-azure-eventhub-integration-sample/src/main/java/example/SendController.java
@@ -8,7 +8,6 @@ package example;
 
 import com.microsoft.azure.spring.integration.core.AzureMessageHandler;
 import com.microsoft.azure.spring.integration.eventhub.EventHubOperation;
-import com.microsoft.azure.spring.integration.eventhub.inbound.EventHubInboundChannelAdapter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-cloud-azure-samples/spring-cloud-azure-eventhub-kafka-sample/src/main/java/com/example/SourceExample.java
+++ b/spring-cloud-azure-samples/spring-cloud-azure-eventhub-kafka-sample/src/main/java/com/example/SourceExample.java
@@ -11,11 +11,8 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDateTime;
 
 /**
  * @author Warren Zhu

--- a/spring-cloud-azure-samples/spring-cloud-azure-servicebus-integration-sample/src/main/java/example/QueueSendController.java
+++ b/spring-cloud-azure-samples/spring-cloud-azure-servicebus-integration-sample/src/main/java/example/QueueSendController.java
@@ -8,7 +8,6 @@ package example;
 
 import com.microsoft.azure.spring.integration.core.AzureMessageHandler;
 import com.microsoft.azure.spring.integration.servicebus.queue.ServiceBusQueueOperation;
-import com.microsoft.azure.spring.integration.servicebus.topic.ServiceBusTopicOperation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-cloud-azure-samples/spring-cloud-azure-servicebus-topic-binder-sample/src/main/java/com/example/SourceExample.java
+++ b/spring-cloud-azure-samples/spring-cloud-azure-servicebus-topic-binder-sample/src/main/java/com/example/SourceExample.java
@@ -11,7 +11,6 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusPartitionBinderTests.java
+++ b/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusPartitionBinderTests.java
@@ -149,7 +149,7 @@ public class ServiceBusPartitionBinderTests extends
         //moduleOutputChannel.send(message);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Message<byte[]>> inboundMessageRef = new AtomicReference();
+        final AtomicReference<Message<byte[]>> inboundMessageRef = new AtomicReference<>();
         moduleInputChannel.subscribe(message1 -> {
             try {
                 inboundMessageRef.set((Message<byte[]>) message1);
@@ -162,7 +162,7 @@ public class ServiceBusPartitionBinderTests extends
         Assert.isTrue(latch.await(5L, TimeUnit.SECONDS), "Failed to receive message");
         Assertions.assertThat(inboundMessageRef.get()).isNotNull();
         Assertions.assertThat(
-                new String((byte[]) ((Message) inboundMessageRef.get()).getPayload(), StandardCharsets.UTF_8))
+                new String(((Message<byte[]>) inboundMessageRef.get()).getPayload(), StandardCharsets.UTF_8))
                   .isEqualTo("foo");
         Assertions.assertThat(inboundMessageRef.get().getHeaders().get("contentType").toString())
                   .isEqualTo("text/plain");

--- a/spring-integration-azure/spring-integration-azure-core/src/main/java/com/microsoft/azure/spring/integration/core/AzureMessageHandler.java
+++ b/spring-integration-azure/spring-integration-azure-core/src/main/java/com/microsoft/azure/spring/integration/core/AzureMessageHandler.java
@@ -68,7 +68,7 @@ public class AzureMessageHandler extends AbstractMessageHandler {
 
         PartitionSupplier partitionSupplier = toPartitionSupplier(message);
         String destination = toDestination(message);
-        CompletableFuture future = this.sendOperation.sendAsync(destination, message, partitionSupplier);
+        CompletableFuture<?> future = this.sendOperation.sendAsync(destination, message, partitionSupplier);
 
         if (this.sync) {
             waitingSendResponse(future, message);

--- a/spring-integration-azure/spring-integration-storage-queue/src/main/java/com/microsoft/azure/spring/integration/storage/queue/factory/StorageQueueClientFactory.java
+++ b/spring-integration-azure/spring-integration-storage-queue/src/main/java/com/microsoft/azure/spring/integration/storage/queue/factory/StorageQueueClientFactory.java
@@ -7,7 +7,6 @@
 package com.microsoft.azure.spring.integration.storage.queue.factory;
 
 import com.microsoft.azure.storage.queue.CloudQueue;
-import com.microsoft.azure.storage.queue.CloudQueueClient;
 
 /**
  * @author Miao Cao


### PR DESCRIPTION
The build process is outputting several warnings, as described in GH-279. This changeset removes some the simpler warnings related to generic typing and unused imports.

This change set does not by itself remove all warnings described in GH-279

Testing is done via existing test runs - no changes or additions to existing behavior was made

I believe this falls under "cosmetic" changes as per the contribution doc, so I left my username off of the author tags