### PR TITLE
add config store operation interface

### DIFF
--- a/spring-cloud-azure-config/pom.xml
+++ b/spring-cloud-azure-config/pom.xml
@@ -37,5 +37,9 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
@@ -39,8 +39,7 @@ import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
  * How to use:
  * <p>
  * HttpGet httpGet = new HttpGet("https://my-config-store.azconfig.io/keys");
- * CloseableHttpResponse response = ConfigHttpClient.execute(httpGet, "my-credential",
- * "my-secret");
+ * CloseableHttpResponse response = ConfigHttpClient.execute(httpGet, "my-credential", "my-secret");
  * <p/>
  */
 @Slf4j

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.spring.cloud.config;
 import com.microsoft.azure.spring.cloud.config.domain.KeyValueItem;
 import org.springframework.lang.Nullable;
 
-import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 /**
@@ -16,19 +15,11 @@ import java.util.List;
  */
 public interface ConfigServiceOperations {
     /**
-     * Find all key-value items in current configuration store.
-     *
-     * @return all key-value items {@link List<KeyValueItem>} in current configuration store, return empty list if
-     *         no key found.
-     */
-    List<KeyValueItem> getAllKeys();
-
-    /**
      * Find all key-value items which key name is prefixed with {@code prefix}, and has {@code label} if provided.
      *
-     * @param prefix key name prefix of which keys will be loaded.
+     * @param prefix key name prefix of which keys will be loaded, is {@link Nullable}.
      * @param label
      * @return all key-value items {@link List<KeyValueItem>} which match given condition.
      */
-    List<KeyValueItem> getKeys(@NotEmpty String prefix, @Nullable String label);
+    List<KeyValueItem> getKeys(@Nullable String prefix, @Nullable String label);
 }

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.cloud.config;
+
+import com.microsoft.azure.spring.cloud.config.domain.KeyValueItem;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Operations to access certain Azure Config Service configuration store.
+ */
+public interface ConfigServiceOperations {
+    /**
+     * Find a config key-value item with given {@code keyName} and {@link Nullable} {@code label}
+     *
+     * @param keyName name of the key
+     * @param label   label of the key, can be null
+     * @return {@link Optional<KeyValueItem>}, if key does not exist, return {@link Optional#empty()}.
+     */
+    Optional<KeyValueItem> getKey(String keyName, @Nullable String label);
+
+    /**
+     * Find all key-value items in current configuration store.
+     *
+     * @return all key-value items {@link List<KeyValueItem>} in current configuration store, return empty list if
+     *         no key found。
+     */
+    List<KeyValueItem> getAllKeys();
+
+    /**
+     * Find all key-value items which key name is prefixed with {@code prefix}, and has {@code label} if provided.
+     *
+     * @param prefix key name prefix of which keys will be loaded.
+     * @param label
+     * @return all key-value items {@link List<KeyValueItem>} which match given condition.
+     */
+    List<KeyValueItem> getKeys(@NotEmpty String prefix, @Nullable String label);
+}

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
@@ -29,7 +29,7 @@ public interface ConfigServiceOperations {
      * Find all key-value items in current configuration store.
      *
      * @return all key-value items {@link List<KeyValueItem>} in current configuration store, return empty list if
-     *         no key found。
+     *         no key found.
      */
     List<KeyValueItem> getAllKeys();
 

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
@@ -10,21 +10,11 @@ import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Operations to access certain Azure Config Service configuration store.
  */
 public interface ConfigServiceOperations {
-    /**
-     * Find a config key-value item with given {@code keyName} and {@link Nullable} {@code label}
-     *
-     * @param keyName name of the key
-     * @param label   label of the key, can be null
-     * @return {@link Optional<KeyValueItem>}, if key does not exist, return {@link Optional#empty()}.
-     */
-    Optional<KeyValueItem> getKey(String keyName, @Nullable String label);
-
     /**
      * Find all key-value items in current configuration store.
      *

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/domain/KeyValueItem.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/domain/KeyValueItem.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.cloud.config.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@NoArgsConstructor
+@Getter @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KeyValueItem {
+    private String etag;
+
+    private String key;
+
+    private String value;
+
+    private String label;
+
+    @JsonProperty("content_type")
+    private String contentType;
+
+    private String[] tags;
+
+    private boolean locked;
+
+    @JsonProperty("last_modified")
+    private Date lastModified;
+}


### PR DESCRIPTION
## Description
Configuration store operation interface, which currently only includes operations might be required by configuring PropertySource.

Test is not included in this PR.
