### PR TITLE
add query config keys implementation

### DIFF
--- a/spring-cloud-azure-config/pom.xml
+++ b/spring-cloud-azure-config/pom.xml
@@ -41,5 +41,9 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
@@ -12,6 +12,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.spring.cloud.config.domain.KeyValueItem;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -20,24 +21,14 @@ import org.apache.http.client.methods.HttpGet;
 import org.springframework.lang.Nullable;
 
 @Slf4j
+@AllArgsConstructor
 public class ConfigServiceTemplate implements ConfigServiceOperations {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private final ConfigHttpClient configClient;
-
     private final String storeEndpoint;
-
     private final String credential;
-
     private final String secret;
-
-    public ConfigServiceTemplate(ConfigHttpClient configClient, String storeEndpoint, String credential,
-            String secret) {
-        this.configClient = configClient;
-        this.storeEndpoint = storeEndpoint;
-        this.credential = credential;
-        this.secret = secret;
-    }
 
     @Override
     public List<KeyValueItem> getKeys(@Nullable String prefix, @Nullable String label) {
@@ -54,7 +45,8 @@ public class ConfigServiceTemplate implements ConfigServiceOperations {
                 return mapper.readValue(node.get("items").toString(),
                         mapper.getTypeFactory().constructCollectionType(List.class, KeyValueItem.class));
             } else {
-                throw new IllegalStateException("Failed to load keys with status code: " + statusCode);
+                throw new IllegalStateException("Failed to load keys with status code: " + statusCode +
+                        ", with reason: " + response.getStatusLine().getReasonPhrase());
             }
         }
         catch (IOException | URISyntaxException e) {

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
@@ -41,7 +41,7 @@ public class ConfigServiceTemplate implements ConfigServiceOperations {
 
     @Override
     public List<KeyValueItem> getKeys(@Nullable String prefix, @Nullable String label) {
-        String requestUri = RestAPIBuilder.buildKVApi(storeEndpoint, prefix, label);
+        String requestUri = new RestAPIBuilder().withEndpoint(storeEndpoint).buildKVApi(prefix, label);
         HttpGet httpGet = new HttpGet(requestUri);
 
         try (CloseableHttpResponse response = configClient.execute(httpGet, credential, secret)) {

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
@@ -35,6 +35,7 @@ public class ConfigServiceTemplate implements ConfigServiceOperations {
         String requestUri = new RestAPIBuilder().withEndpoint(storeEndpoint).buildKVApi(prefix, label);
         HttpGet httpGet = new HttpGet(requestUri);
 
+        log.debug("Querying key-value items from API [{}].", requestUri);
         try (CloseableHttpResponse response = configClient.execute(httpGet, credential, secret)) {
             int statusCode = response.getStatusLine().getStatusCode();
 
@@ -45,12 +46,12 @@ public class ConfigServiceTemplate implements ConfigServiceOperations {
                 return mapper.readValue(node.get("items").toString(),
                         mapper.getTypeFactory().constructCollectionType(List.class, KeyValueItem.class));
             } else {
-                throw new IllegalStateException("Failed to load keys with status code: " + statusCode +
-                        ", with reason: " + response.getStatusLine().getReasonPhrase());
+                throw new IllegalStateException("Failed to load keys from Azure Config Service with status code: "
+                        + statusCode + ", with reason: " + response.getStatusLine().getReasonPhrase());
             }
         }
         catch (IOException | URISyntaxException e) {
-            log.error("Failed to load keys.", e);
+            log.error("Failed to load keys from Azure Config service.", e);
             // TODO (wp) wrap exception as config service specific exception in order to provide fail-fast etc.
             // features?
             throw new IllegalStateException("Failed to load keys from Azure Config service.", e);

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.cloud.config;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.spring.cloud.config.domain.KeyValueItem;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+
+import org.springframework.lang.Nullable;
+
+@Slf4j
+public class ConfigServiceTemplate implements ConfigServiceOperations {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final ConfigHttpClient configClient;
+
+    private final String storeEndpoint;
+
+    private final String credential;
+
+    private final String secret;
+
+    public ConfigServiceTemplate(ConfigHttpClient configClient, String storeEndpoint, String credential,
+            String secret) {
+        this.configClient = configClient;
+        this.storeEndpoint = storeEndpoint;
+        this.credential = credential;
+        this.secret = secret;
+    }
+
+    @Override
+    public List<KeyValueItem> getKeys(@Nullable String prefix, @Nullable String label) {
+        String requestUri = RestAPIBuilder.buildKVApi(storeEndpoint, prefix, label);
+        HttpGet httpGet = new HttpGet(requestUri);
+
+        try (CloseableHttpResponse response = configClient.execute(httpGet, credential, secret)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode == HttpStatus.SC_OK) {
+                ObjectNode node = mapper.readValue(response.getEntity().getContent(), ObjectNode.class);
+
+                // Returned key-value items are stored in the JSON field "items"
+                return mapper.readValue(node.get("items").toString(),
+                        mapper.getTypeFactory().constructCollectionType(List.class, KeyValueItem.class));
+            } else {
+                throw new IllegalStateException("Failed to load keys with status code: " + statusCode);
+            }
+        }
+        catch (IOException | URISyntaxException e) {
+            log.error("Failed to load keys.", e);
+            // TODO (wp) wrap exception as config service specific exception in order to provide fail-fast etc.
+            // features?
+            throw new IllegalStateException("Failed to load keys from Azure Config service.", e);
+        }
+    }
+}

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -20,6 +20,22 @@ import org.springframework.util.StringUtils;
 public class RestAPIBuilder {
     public static final String KEY_VALUE_API = "/kv";
 
+    /**
+     * Build REST API for kv request, depending on prefix and label is empty or not, different URIs will be built.
+     *
+     * <p>
+     * e.g.,
+     *   https://host.domain.io/kv
+     *   https://host.domain.io/kv?key=abc
+     *   https://host.domain.io/kv?key=abc*
+     *   https://host.domain.io/kv?key=abc*&label=prod
+     * </p>
+     *
+     * @param endpoint config store service endpoint, e.g., https://my-test-config.host.domain.io
+     * @param prefix is {@link Nullable}, key name prefix to be searched
+     * @param label  is {@link Nullable}, key label value to be searched
+     * @return valid full path of target REST API
+     */
     public static String buildKVApi(@NonNull String endpoint, @Nullable String prefix, @Nullable String label) {
         Map<String, String> params = new HashMap<>();
         if (StringUtils.hasText(prefix)) {
@@ -42,6 +58,7 @@ public class RestAPIBuilder {
         builder.append(path);
 
         if (params != null && params.size() > 0) {
+            // append query params, example: "?param1=value1&param2=value2"
             builder.append("?");
 
             String queryParams = String.join("&", params.entrySet().stream()

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -70,7 +70,7 @@ public class RestAPIBuilder {
     }
 
     private String buildRequestUri() {
-        Assert.notNull(endpoint, "Endpoint should not be null");
+        Assert.hasText(endpoint, "Endpoint should not be empty or null");
         Assert.hasText(path, "Request path should not be empty or null");
 
         StringBuilder builder = new StringBuilder();

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.cloud.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * This class is used to build REST API uris for different service rest endpoints.
+ */
+public class RestAPIBuilder {
+    public static final String KEY_VALUE_API = "/kv";
+
+    public static String buildKVApi(@NonNull String endpoint, @Nullable String prefix, @Nullable String label) {
+        Map<String, String> params = new HashMap<>();
+        if (StringUtils.hasText(prefix)) {
+            params.put("key", prefix);
+        }
+
+        if (StringUtils.hasText(label)) {
+            params.put("label", label);
+        }
+
+        return buildRequestUri(endpoint, KEY_VALUE_API, params);
+    }
+
+    private static String buildRequestUri(@NonNull String endpoint, String path, Map<String, String> params) {
+        Assert.notNull(endpoint, "Endpoint should not be null");
+        Assert.hasText(path, "Request path should not be empty or null");
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(endpoint);
+        builder.append(path);
+
+        if (params != null && params.size() > 0) {
+            builder.append("?");
+
+            String queryParams = String.join("&", params.entrySet().stream()
+                    .map(p -> p.getKey() + "=" + p.getValue())
+                    .collect(Collectors.toList()));
+
+            builder.append(queryParams);
+        }
+
+        return builder.toString();
+    }
+}

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -19,6 +18,28 @@ import org.springframework.util.StringUtils;
  */
 public class RestAPIBuilder {
     public static final String KEY_VALUE_API = "/kv";
+
+    private String endpoint;
+    private String path;
+    private Map<String, String> params = new HashMap<>();
+
+    public RestAPIBuilder() {
+    }
+
+    public RestAPIBuilder withEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+        return this;
+    }
+
+    public RestAPIBuilder withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public RestAPIBuilder addParam(String key, String value) {
+        this.params.put(key, value);
+        return this;
+    }
 
     /**
      * Build REST API for kv request, depending on prefix and label is empty or not, different URIs will be built.
@@ -31,25 +52,24 @@ public class RestAPIBuilder {
      *   https://host.domain.io/kv?key=abc*&label=prod
      * </p>
      *
-     * @param endpoint config store service endpoint, e.g., https://my-test-config.host.domain.io
      * @param prefix is {@link Nullable}, key name prefix to be searched
      * @param label  is {@link Nullable}, key label value to be searched
      * @return valid full path of target REST API
      */
-    public static String buildKVApi(@NonNull String endpoint, @Nullable String prefix, @Nullable String label) {
-        Map<String, String> params = new HashMap<>();
+    public String buildKVApi(@Nullable String prefix, @Nullable String label) {
+        this.withPath(KEY_VALUE_API);
         if (StringUtils.hasText(prefix)) {
-            params.put("key", prefix);
+            this.addParam("key", prefix);
         }
 
         if (StringUtils.hasText(label)) {
-            params.put("label", label);
+            this.addParam("label", label);
         }
 
-        return buildRequestUri(endpoint, KEY_VALUE_API, params);
+        return buildRequestUri();
     }
 
-    private static String buildRequestUri(@NonNull String endpoint, String path, Map<String, String> params) {
+    private String buildRequestUri() {
         Assert.notNull(endpoint, "Endpoint should not be null");
         Assert.hasText(path, "Request path should not be empty or null");
 

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/domain/KeyValueItem.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/domain/KeyValueItem.java
@@ -10,11 +10,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Date;
 
 @NoArgsConstructor
-@Getter @Setter
+@Getter @Setter @ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KeyValueItem {
     private String etag;

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/domain/KeyValueItem.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/domain/KeyValueItem.java
@@ -15,7 +15,9 @@ import lombok.ToString;
 import java.util.Date;
 
 @NoArgsConstructor
-@Getter @Setter @ToString
+@Getter
+@Setter
+@ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KeyValueItem {
     private String etag;


### PR DESCRIPTION
## Description
1. Implement query keys REST API:
`GET /kv?key={key}&label={label}`

Which returns json response like:
```
{
  "items":[
    {"etag":"fake-etag1","key":"foo","label":"test","content_type":"","value":"bar","tags":[],"locked":false,"last_modified":"2018-11-09T05:31:18+00:00"},
    {"etag":"fake-etag2","key":"test","label":"test","content_type":"","value":"","tags":["en"],"locked":false,"last_modified":"2018-10-24T10:09:43+00:00"}]
}
```

2. Convert the returned json as List of key-value items.


