### PR TITLE
Fix config bug

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
@@ -44,6 +44,7 @@ public class AzureCloudConfigProperties {
 
     // Prefix for all properties, can be empty
     @Nullable
+    @Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")
     private String prefix;
 
     // Label value in the Azure Config Service, can be empty

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
@@ -42,11 +42,7 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<ConfigSe
         List<KeyValueItem> items = source.getKeys(context + "*", label);
 
         for (KeyValueItem item : items) {
-            if (item.getLabel() != label) {
-                continue; // Skip non-expected label
-            }
-
-            String key = item.getKey().replaceFirst(context, "");
+            String key = item.getKey().trim().substring(context.length());
             properties.put(key, item.getValue());
         }
     }

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -62,6 +62,7 @@ public class RestAPIBuilder {
             this.addParam("key", prefix);
         }
 
+        label = label == null ? "%00" : label; // label=%00 matches null label
         if (StringUtils.hasText(label)) {
             this.addParam("label", label);
         }


### PR DESCRIPTION
## Description
Fix config bugs:

1. No restriction for key prefix
2. Null label was search as `*`, by default search null label, and `%00` for null label search, if user needs to search all labels, need to configure `spring.cloud.azure.config.label` as `*`