### PR TITLE
allow configurable order for property source locator

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.spring.cloud.config;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.Ordered;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -55,6 +56,8 @@ public class AzureCloudConfigProperties {
     @NotEmpty
     @Pattern(regexp = "^[a-zA-Z0-9_@]+$")
     private String profileSeparator = "_";
+
+    private int order = Ordered.LOWEST_PRECEDENCE;
 
     // Values extracted from connection string
     private String endpoint;

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocator.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocator.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.spring.cloud.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.Ordered;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
@@ -19,7 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Slf4j
-public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
+public class AzureConfigPropertySourceLocator implements PropertySourceLocator, Ordered {
     private static final String SPRING_APP_NAME_PROP = "spring.application.name";
     private static final String PROPERTY_SOURCE_NAME = "azure-config-store";
     private static final String PATH_SPLITTER = "/";
@@ -28,11 +29,13 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
     private final AzureCloudConfigProperties properties;
     private List<String> contexts = new ArrayList<>();
     private final String profileSeparator;
+    private final int order;
 
     public AzureConfigPropertySourceLocator(ConfigServiceOperations operations, AzureCloudConfigProperties properties) {
         this.operations = operations;
         this.properties = properties;
         this.profileSeparator = properties.getProfileSeparator();
+        this.order = properties.getOrder();
     }
 
     @Override
@@ -98,5 +101,10 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
         propertySource.initProperties();
 
         return propertySource;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
     }
 }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigBootstrapConfigurationTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigBootstrapConfigurationTest.java
@@ -9,9 +9,9 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.Ordered;
 
-import static com.microsoft.azure.spring.cloud.config.TestConstants.CONN_STRING_PROP;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_CONN_STRING;
+import static com.microsoft.azure.spring.cloud.config.TestConstants.*;
 import static com.microsoft.azure.spring.cloud.config.TestUtils.propPair;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,5 +41,16 @@ public class AzureConfigBootstrapConfigurationTest {
     @Test
     public void propertySourceLocatorBeanCreated() {
         contextRunner.run(context -> assertThat(context).hasSingleBean(AzureConfigPropertySourceLocator.class));
+    }
+
+    @Test
+    public void propertySourceLocatorChangeOrder() {
+        contextRunner.run(context -> assertThat(context.getBean(AzureConfigPropertySourceLocator.class).getOrder())
+                .isEqualTo(Ordered.LOWEST_PRECEDENCE));
+
+        assertThat(TEST_LOCATOR_ORDER).isNotEqualTo(Ordered.LOWEST_PRECEDENCE);
+        contextRunner.withPropertyValues(propPair(ORDER_PROP, Integer.toString(TEST_LOCATOR_ORDER))).run(context ->
+                assertThat(context.getBean(AzureConfigPropertySourceLocator.class).getOrder())
+                        .isEqualTo(TEST_LOCATOR_ORDER));
     }
 }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.spring.cloud.config;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.core.Ordered;
 
 /**
  * Test constants which can be shared across different test classes
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestConstants {
     public static final String CONN_STRING_PROP = "spring.cloud.azure.config.connection-string";
+    public static final String ORDER_PROP = "spring.cloud.azure.config.order";
     public static final String DEFAULT_CONTEXT_PROP = "spring.cloud.azure.config.default-context";
     public static final String PREFIX_PROP = "spring.cloud.azure.config.prefix";
     public static final String SEPARATOR_PROP = "spring.cloud.azure.config.profile-separator";
@@ -33,4 +35,6 @@ public class TestConstants {
     public static final String TEST_VALUE_2 = "test_value_2";
     public static final String TEST_KEY_3 = "test_key_3";
     public static final String TEST_VALUE_3 = "test_value_3";
+
+    public static final int TEST_LOCATOR_ORDER = Ordered.HIGHEST_PRECEDENCE;
 }


### PR DESCRIPTION
## Description
Support user to configure the order of AzureConfigPropertySourceLocator , for how to use, refer to the test case configuration.