### PR TITLE
support prop name is splitted by slash

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
@@ -42,7 +42,7 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<ConfigSe
         List<KeyValueItem> items = source.getKeys(context + "*", label);
 
         for (KeyValueItem item : items) {
-            String key = item.getKey().trim().substring(context.length());
+            String key = item.getKey().trim().substring(context.length()).replace('/', '.');
             properties.put(key, item.getValue());
         }
     }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.microsoft.azure.spring.cloud.config.TestConstants.*;
@@ -62,5 +63,21 @@ public class AzureConfigPropertySourceTest {
         assertThat(propertySource.getProperty(TEST_KEY_1)).isEqualTo(TEST_VALUE_1);
         assertThat(propertySource.getProperty(TEST_KEY_2)).isEqualTo(TEST_VALUE_2);
         assertThat(propertySource.getProperty(TEST_KEY_3)).isEqualTo(TEST_VALUE_3);
+    }
+
+    @Test
+    public void testPropertyNameSlashConvertedToDots() {
+        KeyValueItem slashedProp = createItem(TEST_CONTEXT, TEST_SLASH_KEY, TEST_SLASH_VALUE);
+        when(operations.getKeys(anyString(), any())).thenReturn(Arrays.asList(slashedProp));
+
+        propertySource.initProperties();
+
+        String expectedKeyName = TEST_SLASH_KEY.replace('/', '.');
+        String[] actualKeyNames = propertySource.getPropertyNames();
+
+        assertThat(actualKeyNames.length).isEqualTo(1);
+        assertThat(actualKeyNames[0]).isEqualTo(expectedKeyName);
+        assertThat(propertySource.getProperty(TEST_SLASH_KEY)).isNull();
+        assertThat(propertySource.getProperty(expectedKeyName)).isEqualTo(TEST_SLASH_VALUE);
     }
 }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
@@ -33,4 +33,7 @@ public class TestConstants {
     public static final String TEST_VALUE_2 = "test_value_2";
     public static final String TEST_KEY_3 = "test_key_3";
     public static final String TEST_VALUE_3 = "test_value_3";
+
+    public static final String TEST_SLASH_KEY = "test/slash/key";
+    public static final String TEST_SLASH_VALUE = "prop value for slashed key name";
 }


### PR DESCRIPTION
## Description
Slash in prop name will be converted to dots. e.g., `a/b/c` -> `a.b.c`
