### PR TITLE
ignore null or empty application name for property source

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocator.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocator.java
@@ -65,7 +65,7 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
         for (String sourceContext : this.contexts) {
             try {
                 composite.addPropertySource(create(sourceContext));
-                log.debug("PropertySource context {} is added.", sourceContext);
+                log.debug("PropertySource context [{}] is added.", sourceContext);
             } catch (Exception e) {
                 if (properties.isFailFast()) {
                     log.error("Fail fast is set and there was an error reading configuration from Azure Config " +
@@ -82,6 +82,10 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
 
     private List<String> generateContexts(String applicationName, List<String> profiles) {
         List<String> result = new ArrayList<>();
+        if (!StringUtils.hasText(applicationName)) {
+            return result; // Ignore null or empty application name
+        }
+
         String prefix = this.properties.getPrefix();
 
         String prefixedContext = propWithAppName(prefix, applicationName);

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocatorTest.java
@@ -88,6 +88,42 @@ public class AzureConfigPropertySourceLocatorTest {
     }
 
     @Test
+    public void nullApplicationNameCreateDefaultContextOnly() {
+        when(environment.getActiveProfiles()).thenReturn(new String[]{});
+        when(environment.getProperty("spring.application.name")).thenReturn(null);
+        properties.setName(null);
+        locator = new AzureConfigPropertySourceLocator(operations, properties);
+
+        PropertySource<?> source = locator.locate(environment);
+        assertThat(source).isInstanceOf(CompositePropertySource.class);
+
+        Collection<PropertySource<?>> sources = ((CompositePropertySource) source).getPropertySources();
+        // Default context, null application name, empty active profile,
+        // should construct composite Property Source: [/application/]
+        String[] expectedPrefixes = new String[]{"/application/"};
+        assertThat(sources.size()).isEqualTo(1);
+        assertThat(sources.stream().map(s -> s.getName()).toArray()).containsExactly(expectedPrefixes);
+    }
+
+    @Test
+    public void emptyApplicationNameCreateDefaultContextOnly() {
+        when(environment.getActiveProfiles()).thenReturn(new String[]{});
+        when(environment.getProperty("spring.application.name")).thenReturn("");
+        properties.setName("");
+        locator = new AzureConfigPropertySourceLocator(operations, properties);
+
+        PropertySource<?> source = locator.locate(environment);
+        assertThat(source).isInstanceOf(CompositePropertySource.class);
+
+        Collection<PropertySource<?>> sources = ((CompositePropertySource) source).getPropertySources();
+        // Default context, empty application name, empty active profile,
+        // should construct composite Property Source: [/application/]
+        String[] expectedPrefixes = new String[]{"/application/"};
+        assertThat(sources.size()).isEqualTo(1);
+        assertThat(sources.stream().map(s -> s.getName()).toArray()).containsExactly(expectedPrefixes);
+    }
+
+    @Test
     public void defaultFailFastThrowException() {
         final String failureMsg = "Failed to load data from Azure Config Service.";
         expected.expect(RuntimeException.class);


### PR DESCRIPTION
## Description
A "/null/" context will be queried when the spring application is not configured. Which should not be queried at all. 
