### PR TITLE
query empty label as null label in config service

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -62,7 +62,7 @@ public class RestAPIBuilder {
             this.addParam("key", prefix);
         }
 
-        label = StringUtils.isEmpty(label) ? "%00" : label; // label=%00 matches null label
+        label = StringUtils.hasText(label) ? label.trim() : "%00"; // label=%00 matches null label
         if (StringUtils.hasText(label)) {
             this.addParam("label", label);
         }

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -62,7 +62,7 @@ public class RestAPIBuilder {
             this.addParam("key", prefix);
         }
 
-        label = label == null ? "%00" : label; // label=%00 matches null label
+        label = StringUtils.isEmpty(label) ? "%00" : label; // label=%00 matches null label
         if (StringUtils.hasText(label)) {
             this.addParam("label", label);
         }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilderTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilderTest.java
@@ -66,6 +66,18 @@ public class RestAPIBuilderTest {
     }
 
     @Test
+    public void emptyLabelValueQueriedAsEmptyLabel() {
+        final RestAPIBuilder builder = new RestAPIBuilder().withEndpoint(FAKE_ENDPOINT);
+
+        String apiPath = builder.buildKVApi(null, "");
+        Assert.assertTrue("Empty label should have query param %00.", apiPath.endsWith(NULL_LABEL_QUERY));
+
+        apiPath = builder.buildKVApi(null, "  ");
+        Assert.assertTrue("Whitespace consisted label should have query param %00.",
+                apiPath.endsWith(NULL_LABEL_QUERY));
+    }
+
+    @Test
     public void bothKeyAndLabelCanBeConfigured() throws URISyntaxException {
         final RestAPIBuilder builder = new RestAPIBuilder().withEndpoint(FAKE_ENDPOINT);
         String apiPath = builder.buildKVApi(FAKE_KEY, FAKE_LABEL);


### PR DESCRIPTION
## Description
Previously, empty label string is considered as wildcard match.

