### PR TITLE
Fix cloud watch auto configuration and add test case (fix #390)

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigAutoConfiguration.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigAutoConfiguration.java
@@ -16,22 +16,26 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
-@ConditionalOnClass(RefreshEndpoint.class)
-@ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = {"enabled", "watch.enabled"},
-        matchIfMissing = true)
+@ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
 public class AzureCloudConfigAutoConfiguration {
     public static final String WATCH_TASK_SCHEDULER_NAME = "azureConfigWatchTaskScheduler";
 
-    @Bean
-    public AzureCloudConfigWatch getConfigWatch(ConfigServiceOperations operations,
-                                                AzureCloudConfigProperties properties,
-                                                @Qualifier(WATCH_TASK_SCHEDULER_NAME) TaskScheduler scheduler) {
-        return new AzureCloudConfigWatch(operations, properties, scheduler);
-    }
+    @Configuration
+    @ConditionalOnClass(RefreshEndpoint.class)
+    @ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = "watch.enabled",
+            matchIfMissing = true)
+    static class CloudWatchAutoConfiguration {
+        @Bean
+        public AzureCloudConfigWatch getConfigWatch(ConfigServiceOperations operations,
+                                                    AzureCloudConfigProperties properties,
+                                                    @Qualifier(WATCH_TASK_SCHEDULER_NAME) TaskScheduler scheduler) {
+            return new AzureCloudConfigWatch(operations, properties, scheduler);
+        }
 
-    @Bean(name = WATCH_TASK_SCHEDULER_NAME)
-    @ConditionalOnMissingBean
-    public TaskScheduler getTaskScheduler() {
-        return new ThreadPoolTaskScheduler();
+        @Bean(name = WATCH_TASK_SCHEDULER_NAME)
+        @ConditionalOnMissingBean
+        public TaskScheduler getTaskScheduler() {
+            return new ThreadPoolTaskScheduler();
+        }
     }
 }

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigAutoConfiguration.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigAutoConfiguration.java
@@ -17,7 +17,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @ConditionalOnClass(RefreshEndpoint.class)
-@ConditionalOnProperty(name = AzureCloudConfigProperties.CONFIG_PREFIX + ".watch.enabled", matchIfMissing = true)
+@ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = {"enabled", "watch.enabled"},
+        matchIfMissing = true)
 public class AzureCloudConfigAutoConfiguration {
     public static final String WATCH_TASK_SCHEDULER_NAME = "azureConfigWatchTaskScheduler";
 

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigAutoConfigurationTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigAutoConfigurationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.cloud.config;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import static com.microsoft.azure.spring.cloud.config.AzureCloudConfigAutoConfiguration.WATCH_TASK_SCHEDULER_NAME;
+import static com.microsoft.azure.spring.cloud.config.TestConstants.*;
+import static com.microsoft.azure.spring.cloud.config.TestUtils.propPair;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AzureCloudConfigAutoConfigurationTest {
+    private static final TaskScheduler TEST_SCHEDULER = new ThreadPoolTaskScheduler();
+    private static final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues(propPair(CONN_STRING_PROP, TEST_CONN_STRING))
+            .withConfiguration(AutoConfigurations.of(AzureConfigBootstrapConfiguration.class,
+                    AzureCloudConfigAutoConfiguration.class));
+
+    @Test
+    public void configNotEnabledWatchNotEnabledShouldNotCreateWatch() {
+        contextRunner.withPropertyValues(propPair(CONFIG_ENABLED_PROP, "false"),
+                propPair(WATCH_ENABLED_PROP, "false")).run(context -> {
+           assertThat(context).doesNotHaveBean(AzureCloudConfigWatch.class);
+           assertThat(context).doesNotHaveBean(WATCH_TASK_SCHEDULER_NAME);
+        });
+    }
+
+    @Test
+    public void configNotEnabledWatchEnabledShouldNotCreateWatch() {
+        contextRunner.withPropertyValues(propPair(CONFIG_ENABLED_PROP, "false"),
+                propPair(WATCH_ENABLED_PROP, "true")).run(context -> {
+            assertThat(context).doesNotHaveBean(AzureCloudConfigWatch.class);
+            assertThat(context).doesNotHaveBean(WATCH_TASK_SCHEDULER_NAME);
+        });
+    }
+
+    @Test
+    public void configEnabledWatchNotEnabledShouldNotCreateWatch() {
+        contextRunner.withPropertyValues(propPair(CONFIG_ENABLED_PROP, "true"),
+                propPair(WATCH_ENABLED_PROP, "false")).run(context -> {
+            assertThat(context).doesNotHaveBean(AzureCloudConfigWatch.class);
+            assertThat(context).doesNotHaveBean(WATCH_TASK_SCHEDULER_NAME);
+        });
+    }
+
+    @Test
+    public void configEnabledWatchEnabledShouldCreateWatch() {
+        contextRunner.withPropertyValues(propPair(CONFIG_ENABLED_PROP, "true"),
+                propPair(WATCH_ENABLED_PROP, "true")).run(context -> {
+            assertThat(context).hasSingleBean(AzureCloudConfigWatch.class);
+            assertThat(context).hasBean(WATCH_TASK_SCHEDULER_NAME);
+            assertThat(context).hasSingleBean(TaskScheduler.class);
+        });
+    }
+
+    @Test
+    public void taskSchedulerCanBeCustomizedByUser() {
+        contextRunner.withPropertyValues(propPair(CONFIG_ENABLED_PROP, "true"),
+                propPair(WATCH_ENABLED_PROP, "true"))
+                .withUserConfiguration(TestConfiguration.class).run(context -> {
+            assertThat(context).hasSingleBean(AzureCloudConfigWatch.class);
+            assertThat(context).hasBean(WATCH_TASK_SCHEDULER_NAME);
+            assertThat(context).hasSingleBean(TaskScheduler.class);
+            assertThat(context.getBean(WATCH_TASK_SCHEDULER_NAME)).isEqualTo(TEST_SCHEDULER);
+        });
+    }
+
+    @Configuration
+    static class TestConfiguration {
+        @Bean(name = WATCH_TASK_SCHEDULER_NAME)
+        public TaskScheduler getTaskScheduler() {
+            return TEST_SCHEDULER;
+        }
+    }
+}

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
@@ -15,6 +15,8 @@ import lombok.NoArgsConstructor;
 public class TestConstants {
     public static final String CONN_STRING_PROP = "spring.cloud.azure.config.connection-string";
     public static final String DEFAULT_CONTEXT_PROP = "spring.cloud.azure.config.default-context";
+    public static final String CONFIG_ENABLED_PROP = "spring.cloud.azure.config.enabled";
+    public static final String WATCH_ENABLED_PROP = "spring.cloud.azure.config.watch.enabled";
     public static final String PREFIX_PROP = "spring.cloud.azure.config.prefix";
     public static final String SEPARATOR_PROP = "spring.cloud.azure.config.profile-separator";
     public static final String SUBSCRIPTION_ID_PROP = "spring.cloud.azure.config.arm.subscription-id";


### PR DESCRIPTION
## Description
1. Fix config not enabled, config watch being created
2. Test the cloud watch related auto configuration

refs #390 
