### PR TITLE
support multiple stores in the configuration properties

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
@@ -63,10 +63,7 @@ public class AzureCloudConfigProperties {
             return;
         }
 
-        stores.forEach(store -> storeMap.put(store.getName(),
-                ConnectionString.of(store.getConnectionString())));
-
-        Assert.notEmpty(stores, "No config store has been configured under spring.cloud.config.stores");
+        stores.forEach(store -> storeMap.put(store.getName(), ConnectionString.of(store.getConnectionString())));
     }
 
     class Watch {

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
@@ -12,12 +12,16 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
 
 @Validated
 @Getter
@@ -25,16 +29,10 @@ import javax.validation.constraints.Pattern;
 @ConfigurationProperties(prefix = AzureCloudConfigProperties.CONFIG_PREFIX)
 public class AzureCloudConfigProperties {
     public static final String CONFIG_PREFIX = "spring.cloud.azure.config";
-    private static final String CONN_STRING_SPLITTER = ";";
-    private static final String ENDPOINT_PREFIX = "endpoint=";
-    private static final String ID_PREFIX = "id=";
-    private static final String SECRET_PREFIX = "secret=";
-    public static final String NON_EMPTY_MSG = "%s property should not be null or empty in the connection string of " +
-            "Azure Config Service.";
 
     private boolean enabled = true;
 
-    private String connectionString;
+    private List<ConfigStore> stores = new ArrayList<>();
 
     @NotEmpty
     private String defaultContext = "application";
@@ -42,15 +40,6 @@ public class AzureCloudConfigProperties {
     // Alternative to Spring application name, if not configured, fallback to default Spring application name
     @Nullable
     private String name;
-
-    // Prefix for all properties, can be empty
-    @Nullable
-    @Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")
-    private String prefix;
-
-    // Label value in the Azure Config Service, can be empty
-    @Nullable
-    private String label;
 
     // Profile separator for the key name, e.g., /foo-app_dev/db.connection.key
     @NotEmpty
@@ -65,48 +54,19 @@ public class AzureCloudConfigProperties {
 
     private AzureCloudConfigARMProperties arm;
 
-    // Values extracted from connection string
-    private String endpoint;
-    private String id;
-    private String secret;
-
-    public String getEndpoint() {
-        return endpoint;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getSecret() {
-        return secret;
-    }
+    // Initialized from the loaded properties
+    private Map<String, ConnectionString> storeMap = new HashMap<>();
 
     @PostConstruct
     public void validateAndInit() {
-        if (!StringUtils.hasText(connectionString)) {
+        if (stores.isEmpty()) {
             return;
         }
 
-        String[] items = connectionString.split(CONN_STRING_SPLITTER);
-        for (String item : items) {
-            if (!StringUtils.hasText(item)) {
-                continue;
-            }
+        stores.forEach(store -> storeMap.put(store.getName(),
+                ConnectionString.of(store.getConnectionString())));
 
-            String lowerCasedItem = item.toLowerCase();
-            if (lowerCasedItem.startsWith(ENDPOINT_PREFIX)) {
-                this.endpoint = item.substring(ENDPOINT_PREFIX.length());
-            } else if (lowerCasedItem.startsWith(ID_PREFIX)) {
-                this.id = item.substring(ID_PREFIX.length());
-            } else if (lowerCasedItem.startsWith(SECRET_PREFIX)) {
-                this.secret = item.substring(SECRET_PREFIX.length());
-            }
-        }
-
-        Assert.hasText(this.endpoint, String.format(NON_EMPTY_MSG, "Endpoint"));
-        Assert.hasText(this.id, String.format(NON_EMPTY_MSG, "Id"));
-        Assert.hasText(this.secret, String.format(NON_EMPTY_MSG, "Secret"));
+        Assert.notEmpty(stores, "No config store has been configured under spring.cloud.config.stores");
     }
 
     class Watch {
@@ -131,5 +91,97 @@ public class AzureCloudConfigProperties {
         public void setDelay(int delay) {
             this.delay = delay;
         }
+    }
+}
+
+class ConfigStore {
+    private String name; // Config store name
+    @Nullable
+    @Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")
+    private String prefix;
+    private String connectionString;
+    // Label value in the Azure Config Service, can be empty
+    @Nullable
+    private String label;
+
+    public ConfigStore() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+}
+
+class ConnectionString {
+    private static final String CONN_STRING_REGEXP = "Endpoint=(.*?);Id=(.*?);Secret=(.*?)";
+    public static final String ENDPOINT_ERR_MSG = String.format("Connection string does not follow format %s.",
+            CONN_STRING_REGEXP);
+    private static final java.util.regex.Pattern CONN_STRING_PATTERN =
+            java.util.regex.Pattern.compile(CONN_STRING_REGEXP);
+
+    private String endpoint;
+    private String id;
+    private String secret;
+
+    public ConnectionString(String endpoint, String id, String secret) {
+        this.endpoint = endpoint;
+        this.id = id;
+        this.secret = secret;
+    }
+
+    static ConnectionString of(String connectionString) {
+        Assert.hasText(connectionString, String.format("Connection string cannot be empty."));
+
+        Matcher matcher = CONN_STRING_PATTERN.matcher(connectionString);
+        if (!matcher.find()) {
+            throw new IllegalStateException(String.format("Connection string does not follow format %s.",
+                    CONN_STRING_REGEXP));
+        }
+
+        String endpoint = matcher.group(1);
+        String id = matcher.group(2);
+        String secret = matcher.group(3);
+
+        return new ConnectionString(endpoint, id, secret);
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSecret() {
+        return secret;
     }
 }

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigWatch.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigWatch.java
@@ -34,12 +34,15 @@ public class AzureCloudConfigWatch implements ApplicationEventPublisherAware, Sm
     private ScheduledFuture<?> watchFuture;
     private AzureCloudConfigProperties properties;
     private boolean firstTime = true;
+    // TODO (wp) multi stores is not supported yet
+    private ConfigStore configStore;
 
     public AzureCloudConfigWatch(ConfigServiceOperations operations, AzureCloudConfigProperties properties,
                                  TaskScheduler scheduler) {
         this.configOperations = operations;
         this.properties = properties;
         this.taskScheduler = scheduler;
+        this.configStore = properties.getStores().get(0);
     }
 
     @Override
@@ -85,8 +88,8 @@ public class AzureCloudConfigWatch implements ApplicationEventPublisherAware, Sm
 
     public void watchConfigKeyValues() {
         if (this.running.get()) {
-            String prefix = StringUtils.hasText(properties.getPrefix()) ? properties.getPrefix() + "*" : "*";
-            List<KeyValueItem> keyValueItems = configOperations.getKeys(prefix, properties.getLabel());
+            String prefix = StringUtils.hasText(configStore.getPrefix()) ? configStore.getPrefix() + "*" : "*";
+            List<KeyValueItem> keyValueItems = configOperations.getKeys(prefix, configStore.getLabel());
 
             if (keyValueItems.isEmpty()) {
                 return;

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
@@ -17,12 +17,15 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<ConfigSe
     private final String context;
     private final AzureCloudConfigProperties configProperties;
     private Map<String, Object> properties = new LinkedHashMap<>();
+    // TODO (wp) multi stores is not supported yet
+    private ConfigStore configStore;
 
     public AzureConfigPropertySource(String context, AzureCloudConfigProperties configProperties,
                                      ConfigServiceOperations operations) {
         super(context, operations);
         this.configProperties = configProperties;
         this.context = context;
+        this.configStore = configProperties.getStores().get(0);
     }
 
     @Override
@@ -37,7 +40,7 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<ConfigSe
     }
 
     public void initProperties() {
-        String label = configProperties.getLabel();
+        String label = this.configStore.getLabel();
         // * for wildcard match
         List<KeyValueItem> items = source.getKeys(context + "*", label);
 

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocator.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocator.java
@@ -14,10 +14,7 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
@@ -29,11 +26,14 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
     private final AzureCloudConfigProperties properties;
     private List<String> contexts = new ArrayList<>();
     private final String profileSeparator;
+    // TODO (wp) multi stores is not supported yet
+    private ConfigStore configStore;
 
     public AzureConfigPropertySourceLocator(ConfigServiceOperations operations, AzureCloudConfigProperties properties) {
         this.operations = operations;
         this.properties = properties;
         this.profileSeparator = properties.getProfileSeparator();
+        this.configStore = properties.getStores().get(0);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
             return result; // Ignore null or empty application name
         }
 
-        String prefix = this.properties.getPrefix();
+        String prefix = this.configStore.getPrefix();
 
         String prefixedContext = propWithAppName(prefix, applicationName);
         result.add(prefixedContext + PATH_SPLITTER);

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigPropertiesTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigPropertiesTest.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.Arrays;
 
-import static com.microsoft.azure.spring.cloud.config.AzureCloudConfigProperties.NON_EMPTY_MSG;
+import static com.microsoft.azure.spring.cloud.config.ConnectionString.ENDPOINT_ERR_MSG;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.*;
 import static com.microsoft.azure.spring.cloud.config.TestUtils.propPair;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,22 +39,22 @@ public class AzureCloudConfigPropertiesTest {
 
     @Test
     public void endpointMustExistInConnectionString() {
-        testConnStringFields(NO_ENDPOINT_CONN_STRING, "Endpoint");
+        testConnStringFields(NO_ENDPOINT_CONN_STRING);
     }
 
     @Test
     public void idMustExistInConnectionString() {
-        testConnStringFields(NO_ID_CONN_STRING, "Id");
+        testConnStringFields(NO_ID_CONN_STRING);
     }
 
     @Test
     public void secretMustExistInConnectionString() {
-        testConnStringFields(NO_SECRET_CONN_STRING, "Secret");
+        testConnStringFields(NO_SECRET_CONN_STRING);
     }
 
-    private void testConnStringFields(String connString, String fieldName) {
+    private void testConnStringFields(String connString) {
         this.contextRunner.withPropertyValues(propPair(CONN_STRING_PROP, connString)).run(context -> {
-            assertThat(context).getFailure().hasStackTraceContaining(String.format(NON_EMPTY_MSG, fieldName));
+            assertThat(context).getFailure().hasStackTraceContaining(ENDPOINT_ERR_MSG);
         });
     }
 

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigBootstrapConfigurationTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigBootstrapConfigurationTest.java
@@ -17,9 +17,10 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.springframework.beans.BeanInstantiationException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Map;
 
 import static com.microsoft.azure.spring.cloud.config.TestConstants.*;
 import static com.microsoft.azure.spring.cloud.config.TestUtils.propPair;
@@ -89,7 +90,7 @@ public class AzureConfigBootstrapConfigurationTest {
                         context.getBean(AzureCloudConfigProperties.class);
                         Assert.fail("When using MSI auth, empty connection string should fail.");
                     } catch (Exception e) {
-                        assertThat(context).getFailure().hasCauseInstanceOf(BeanInstantiationException.class);
+                        assertThat(context).getFailure().hasCauseInstanceOf(IllegalArgumentException.class);
                         assertThat(context).getFailure().hasStackTraceContaining("Connection string cannot be empty");
                     }
                 });
@@ -112,7 +113,8 @@ public class AzureConfigBootstrapConfigurationTest {
         contextRunner.run(context -> {
             assertThat(context.getBean(AzureCloudConfigProperties.class)).isNotNull();
             AzureCloudConfigProperties properties = context.getBean(AzureCloudConfigProperties.class);
-            assertThat(properties.getConnectionString()).isEqualTo(TEST_CONN_STRING);
+            ConfigStore store = properties.getStores().get(0);
+            assertThat(store.getConnectionString()).isEqualTo(TEST_CONN_STRING);
         });
     }
 }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigCloudWatchTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigCloudWatchTest.java
@@ -19,6 +19,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_CONN_STRING;
+import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -40,6 +42,7 @@ public class AzureConfigCloudWatchTest {
         MockitoAnnotations.initMocks(this);
         scheduler = new ThreadPoolTaskScheduler();
         ((ThreadPoolTaskScheduler) scheduler).initialize();
+        TestUtils.addStore(properties, TEST_STORE_NAME, TEST_CONN_STRING);
         watch = new AzureCloudConfigWatch(configOperations, properties, scheduler);
         watch.setApplicationEventPublisher(eventPublisher);
     }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocatorTest.java
@@ -18,6 +18,7 @@ import org.springframework.core.env.PropertySource;
 import java.util.Collection;
 
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_CONN_STRING;
+import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,7 +49,7 @@ public class AzureConfigPropertySourceLocatorTest {
         when(environment.getActiveProfiles()).thenReturn(new String[]{PROFILE_NAME_1, PROFILE_NAME_2});
 
         properties = new AzureCloudConfigProperties();
-        properties.setConnectionString(TEST_CONN_STRING);
+        TestUtils.addStore(properties, TEST_STORE_NAME, TEST_CONN_STRING);
         properties.setName(APPLICATION_NAME);
 
         locator = new AzureConfigPropertySourceLocator(operations, properties);
@@ -70,7 +71,7 @@ public class AzureConfigPropertySourceLocatorTest {
 
     @Test
     public void compositeSourceIsCreatedForPrefixedConfig() {
-        properties.setPrefix(PREFIX);
+        properties.getStores().get(0).setPrefix(PREFIX);
         locator = new AzureConfigPropertySourceLocator(operations, properties);
 
         PropertySource<?> source = locator.locate(environment);

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceTest.java
@@ -12,9 +12,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import static com.microsoft.azure.spring.cloud.config.TestConstants.*;
 import static com.microsoft.azure.spring.cloud.config.TestUtils.createItem;
@@ -37,7 +35,7 @@ public class AzureConfigPropertySourceTest {
 
     @BeforeClass
     public static void init() {
-        TEST_PROPS.setConnectionString(TEST_CONN_STRING);
+        TestUtils.addStore(TEST_PROPS, TEST_STORE_NAME, TEST_CONN_STRING);
 
         TEST_ITEMS.add(item1);
         TEST_ITEMS.add(item2);

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
@@ -13,11 +13,14 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestConstants {
-    public static final String CONN_STRING_PROP = "spring.cloud.azure.config.connection-string";
+    // Store specific configuration
+    public static final String TEST_STORE_NAME = "store1";
+    public static final String CONN_STRING_PROP = "spring.cloud.azure.config.stores[0].connection-string";
+    public static final String PREFIX_PROP = "spring.cloud.azure.config.stores[0].prefix";
+
     public static final String DEFAULT_CONTEXT_PROP = "spring.cloud.azure.config.default-context";
     public static final String CONFIG_ENABLED_PROP = "spring.cloud.azure.config.enabled";
     public static final String WATCH_ENABLED_PROP = "spring.cloud.azure.config.watch.enabled";
-    public static final String PREFIX_PROP = "spring.cloud.azure.config.prefix";
     public static final String SEPARATOR_PROP = "spring.cloud.azure.config.profile-separator";
     public static final String SUBSCRIPTION_ID_PROP = "spring.cloud.azure.config.arm.subscription-id";
     public static final String RESOURCE_GROUP_PROP = "spring.cloud.azure.config.arm.resource-group-name";

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestUtils.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestUtils.java
@@ -9,6 +9,8 @@ import com.microsoft.azure.spring.cloud.config.domain.KeyValueItem;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 /**
  * Utility methods which can be used across different test classes
  */
@@ -24,5 +26,14 @@ public class TestUtils {
         item.setValue(value);
 
         return item;
+    }
+
+    static void addStore(AzureCloudConfigProperties properties, String storeName, String connectionString) {
+        List<ConfigStore> stores = properties.getStores();
+        ConfigStore store = new ConfigStore();
+        store.setConnectionString(connectionString);
+        store.setName(storeName);
+        stores.add(store);
+        properties.setStores(stores);
     }
 }


### PR DESCRIPTION
## Description
Support multiple config stores in the properties, e.g.,
```yaml
spring:
  cloud:
    azure:
      config:
        stores:
          - name: my-store
            prefix: /config
            connection-string: config-store-connection-string
            label: v1
```
For the test cases and Auto Configurations, in this PR, only one config store is considered, which will not be the actual case, will improve in other PRs.