### PR TITLE
support query by multiple labels and result sort by labels

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
@@ -21,6 +21,7 @@ import java.util.List;
 @ConfigurationProperties(prefix = AzureCloudConfigProperties.CONFIG_PREFIX)
 public class AzureCloudConfigProperties {
     public static final String CONFIG_PREFIX = "spring.cloud.azure.config";
+    public static final String LABEL_SEPARATOR = ",";
 
     private boolean enabled = true;
 
@@ -160,7 +161,7 @@ class ConfigStore {
 
     private String connectionString;
 
-    // Label value in the Azure Config Service, can be empty
+    // Label values separated by comma in the Azure Config Service, can be empty
     @Nullable
     private String label;
 

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigWatch.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigWatch.java
@@ -92,7 +92,7 @@ public class AzureCloudConfigWatch implements ApplicationEventPublisherAware, Sm
 
         for (ConfigStore configStore : configStores) {
             String prefix = StringUtils.hasText(configStore.getPrefix()) ? configStore.getPrefix() + "*" : "*";
-            List<KeyValueItem> keyValueItems = configOperations.getKeys(prefix, configStore.getLabel(), configStore);
+            List<KeyValueItem> keyValueItems = configOperations.getKeys(prefix, configStore);
 
             if (keyValueItems.isEmpty()) {
                 return;

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySource.java
@@ -38,7 +38,7 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<ConfigSe
     public void initProperties() {
         String label = this.configStore.getLabel();
         // * for wildcard match
-        List<KeyValueItem> items = source.getKeys(context + "*", label, configStore);
+        List<KeyValueItem> items = source.getKeys(context + "*", configStore);
 
         for (KeyValueItem item : items) {
             String key = item.getKey().trim().substring(context.length()).replace('/', '.');

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceOperations.java
@@ -19,9 +19,8 @@ public interface ConfigServiceOperations {
      * Find all key-value items which key name is prefixed with {@code prefix}, and has {@code label} if provided.
      *
      * @param prefix key name prefix of which keys will be loaded, is {@link Nullable}.
-     * @param label
-     * @param store the config store from which to get keys
+     * @param store the configuration for the config store from which to get keys
      * @return all key-value items {@link List<KeyValueItem>} which match given condition.
      */
-    List<KeyValueItem> getKeys(@Nullable String prefix, @Nullable String label, @NonNull ConfigStore store);
+    List<KeyValueItem> getKeys(@Nullable String prefix, @NonNull ConfigStore store);
 }

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/RestAPIBuilder.java
@@ -67,7 +67,7 @@ public class RestAPIBuilder {
         }
 
         String label = NULL_LABEL;
-        if (labels != null) {
+        if (labels != null && !labels.isEmpty()) {
             labels = labels.stream().filter(l -> StringUtils.hasText(l))
                     .map(l -> l.trim()).distinct().collect(Collectors.toList());
 

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigCloudWatchTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigCloudWatchTest.java
@@ -55,7 +55,7 @@ public class AzureConfigCloudWatchTest {
     @Test
     public void firstCallShouldNotPublishEvent() {
         List<KeyValueItem> mockResponse = initialResponse();
-        when(configOperations.getKeys(any(), any(), any())).thenReturn(mockResponse);
+        when(configOperations.getKeys(any(), any())).thenReturn(mockResponse);
         watch.start();
         watch.watchConfigKeyValues();
         verify(eventPublisher, times(0)).publishEvent(any(RefreshEvent.class));
@@ -64,12 +64,12 @@ public class AzureConfigCloudWatchTest {
     @Test
     public void updatedEtagShouldPublishEvent() throws InterruptedException {
         List<KeyValueItem> mockResponse = initialResponse();
-        when(configOperations.getKeys(any(), any(), any())).thenReturn(mockResponse);
+        when(configOperations.getKeys(any(), any())).thenReturn(mockResponse);
         watch.start();
         watch.watchConfigKeyValues();
 
         List<KeyValueItem> updatedResponse = updatedResponse();
-        when(configOperations.getKeys(any(), any(), any())).thenReturn(updatedResponse);
+        when(configOperations.getKeys(any(), any())).thenReturn(updatedResponse);
         Thread.sleep(properties.getWatch().getDelay() * 2);
         verify(eventPublisher, times(1)).publishEvent(any(RefreshEvent.class));
     }

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceLocatorTest.java
@@ -130,7 +130,7 @@ public class AzureConfigPropertySourceLocatorTest {
         expected.expect(RuntimeException.class);
         expected.expectMessage(failureMsg);
 
-        when(operations.getKeys(any(), any(), any())).thenThrow(new IllegalStateException(failureMsg));
+        when(operations.getKeys(any(), any())).thenThrow(new IllegalStateException(failureMsg));
         assertThat(properties.isFailFast()).isTrue();
         locator.locate(environment);
     }
@@ -139,8 +139,8 @@ public class AzureConfigPropertySourceLocatorTest {
     public void notFailFastShouldPass() {
         properties.setFailFast(false);
         locator = new AzureConfigPropertySourceLocator(operations, properties);
-        when(operations.getKeys(eq("/foo/*"), any(), any())).thenThrow(new IllegalStateException());
-        when(operations.getKeys(eq("/application/*"), any(), any())).thenThrow(new IllegalStateException());
+        when(operations.getKeys(eq("/foo/*"), any())).thenThrow(new IllegalStateException());
+        when(operations.getKeys(eq("/application/*"), any())).thenThrow(new IllegalStateException());
 
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureConfigPropertySourceTest.java
@@ -24,9 +24,9 @@ import static org.mockito.Mockito.when;
 public class AzureConfigPropertySourceTest {
     private static final AzureCloudConfigProperties TEST_PROPS = new AzureCloudConfigProperties();
     public static final List<KeyValueItem> TEST_ITEMS = new ArrayList<>();
-    private static final KeyValueItem item1 = createItem(TEST_CONTEXT, TEST_KEY_1, TEST_VALUE_1);
-    private static final KeyValueItem item2 = createItem(TEST_CONTEXT, TEST_KEY_2, TEST_VALUE_2);
-    private static final KeyValueItem item3 = createItem(TEST_CONTEXT, TEST_KEY_3, TEST_VALUE_3);
+    private static final KeyValueItem item1 = createItem(TEST_CONTEXT, TEST_KEY_1, TEST_VALUE_1, TEST_LABEL_1);
+    private static final KeyValueItem item2 = createItem(TEST_CONTEXT, TEST_KEY_2, TEST_VALUE_2, TEST_LABEL_2);
+    private static final KeyValueItem item3 = createItem(TEST_CONTEXT, TEST_KEY_3, TEST_VALUE_3, TEST_LABEL_3);
 
     private AzureConfigPropertySource propertySource;
 
@@ -46,7 +46,7 @@ public class AzureConfigPropertySourceTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         propertySource = new AzureConfigPropertySource(TEST_CONTEXT, operations, TEST_PROPS.getStores().get(0));
-        when(operations.getKeys(anyString(), any(), any())).thenReturn(TEST_ITEMS);
+        when(operations.getKeys(anyString(), any())).thenReturn(TEST_ITEMS);
     }
 
     @Test
@@ -65,8 +65,8 @@ public class AzureConfigPropertySourceTest {
 
     @Test
     public void testPropertyNameSlashConvertedToDots() {
-        KeyValueItem slashedProp = createItem(TEST_CONTEXT, TEST_SLASH_KEY, TEST_SLASH_VALUE);
-        when(operations.getKeys(anyString(), any(), any())).thenReturn(Arrays.asList(slashedProp));
+        KeyValueItem slashedProp = createItem(TEST_CONTEXT, TEST_SLASH_KEY, TEST_SLASH_VALUE, null);
+        when(operations.getKeys(anyString(), any())).thenReturn(Arrays.asList(slashedProp));
 
         propertySource.initProperties();
 

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
@@ -22,32 +22,29 @@ public class TestConstants {
     public static final String CONFIG_ENABLED_PROP = "spring.cloud.azure.config.enabled";
     public static final String WATCH_ENABLED_PROP = "spring.cloud.azure.config.watch.enabled";
     public static final String SEPARATOR_PROP = "spring.cloud.azure.config.profile-separator";
-    public static final String SUBSCRIPTION_ID_PROP = "spring.cloud.azure.config.arm.subscription-id";
-    public static final String RESOURCE_GROUP_PROP = "spring.cloud.azure.config.arm.resource-group-name";
-    public static final String CONFIG_STORE_PROP = "spring.cloud.azure.config.arm.config-store-name";
     public static final String MSI_ENABLED_PROP = "spring.cloud.azure.config.msi-enabled";
 
     public static final String TEST_CONN_STRING =
             "Endpoint=https://fake.test.config.io;Id=fake-conn-id;Secret=ZmFrZS1jb25uLXNlY3JldA==";
 
+    public static final String LABEL_PARAM = "label";
     public static final String TEST_ENDPOINT = "https://fake.test.config.io";
     public static final String TEST_KV_API = TEST_ENDPOINT + "/kv?key=fake-key*&label=fake-label";
     public static final String TEST_ID = "fake-conn-id";
     public static final String TEST_SECRET = "ZmFrZS1jb25uLXNlY3JldA=="; // Base64 encoded from fake-conn-secret
-
-    public static final String TEST_SUBSCRIPTION_ID = "fake-subscription-id";
-    public static final String TEST_RESOURCE_GROUP = "fake-resource-group";
-    public static final String TEST_CONFIG_STORE = "fake-config-store";
 
     public static final String MSI_TOKEN = "fake_token";
 
     public static final String TEST_CONTEXT = "/foo/";
     public static final String TEST_KEY_1 = "test_key_1";
     public static final String TEST_VALUE_1 = "test_value_1";
+    public static final String TEST_LABEL_1 = "test_label_1";
     public static final String TEST_KEY_2 = "test_key_2";
     public static final String TEST_VALUE_2 = "test_value_2";
+    public static final String TEST_LABEL_2 = "test_label_2";
     public static final String TEST_KEY_3 = "test_key_3";
     public static final String TEST_VALUE_3 = "test_value_3";
+    public static final String TEST_LABEL_3 = "test_label_3";
 
     public static final String TEST_SLASH_KEY = "test/slash/key";
     public static final String TEST_SLASH_VALUE = "prop value for slashed key name";

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestUtils.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestUtils.java
@@ -19,10 +19,11 @@ public class TestUtils {
         return String.format("%s=%s", propName, propValue);
     }
 
-    static KeyValueItem createItem(String context, String key, String value) {
+    static KeyValueItem createItem(String context, String key, String value, String label) {
         KeyValueItem item = new KeyValueItem();
         item.setKey(context + key);
         item.setValue(value);
+        item.setLabel(label);
 
         return item;
     }


### PR DESCRIPTION
## Description
- Allows user configure multiple labels.
- The searched result is ordered by configured labels.

Sample configuration:
```yaml
spring:
  cloud:
    azure:
      config:
        stores:
          - name: my-store
            connection-string: my-connection-string
            label: label1, label2 
```