### PR TITLE
disable watch by default and increase default polling interval

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigProperties.java
@@ -144,8 +144,8 @@ public class AzureCloudConfigProperties {
     }
 
     class Watch {
-        private boolean enabled = true;
-        private int delay = 1000; /* milli-seconds */
+        private boolean enabled = false;
+        private int delay = 5000; /* milli-seconds */
 
         public Watch() {
         }

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-config/README.md
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-config/README.md
@@ -34,8 +34,8 @@ spring.cloud.azure.config.name | Alternative to Spring application name, if not 
 spring.cloud.azure.config.profile-separator | Profile separator for the key name, e.g., /foo-app_dev/db.connection.key, must follow format `^[a-zA-Z0-9_@]+$` | No | `_`
 spring.cloud.azure.config.fail-fast | Whether throw RuntimeException or not when exception occurs | No |  true
 spring.cloud.azure.config.msi-enabled | Whether load connection string from [Azure Resource Manager](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview) with [managed service identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) token or not | No | false
-spring.cloud.azure.config.watch.enabled | Whether enable watch feature or not | No | true
-spring.cloud.azure.config.watch.delay | Delay in milli-seconds between each watch schedule | No | 1000ms
+spring.cloud.azure.config.watch.enabled | Whether enable watch feature or not | No | false
+spring.cloud.azure.config.watch.delay | Polling interval in milli-seconds between each scheduled polling | No | 5000
 spring.cloud.azure.config.msi.client-id | Client id of the managed identity | No | null
 spring.cloud.azure.config.msi.object-id | Object id of the managed identity | No | null
 


### PR DESCRIPTION
## Description
Disable watch by default and increase default polling interval time, in order to save users' bandwidth by default.
