### PR TITLE
remove msi-enabled property and rename msi to managed identity

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigBootstrapConfiguration.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/AzureConfigBootstrapConfiguration.java
@@ -10,12 +10,14 @@ import com.microsoft.azure.credentials.AppServiceMSICredentials;
 import com.microsoft.azure.credentials.AzureTokenCredentials;
 import com.microsoft.azure.credentials.MSICredentials;
 import com.microsoft.azure.spring.cloud.autoconfigure.telemetry.TelemetryCollector;
-import com.microsoft.azure.spring.cloud.config.msi.AzureCloudConfigMSIProperties;
-import com.microsoft.azure.spring.cloud.config.msi.AzureConfigMSIConnector;
+import com.microsoft.azure.spring.cloud.config.managed.identity.AzureManagedIdentityProperties;
+import com.microsoft.azure.spring.cloud.config.managed.identity.AzureResourceManagerConnector;
 import com.microsoft.azure.spring.cloud.config.resource.ConnectionString;
 import com.microsoft.azure.spring.cloud.config.resource.ConnectionStringPool;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -32,6 +34,7 @@ import java.util.List;
 @ConditionalOnClass(AzureConfigPropertySourceLocator.class)
 @ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
 public class AzureConfigBootstrapConfiguration {
+    private static final Logger LOGGER =  LoggerFactory.getLogger(AzureConfigBootstrapConfiguration.class);
     private static final String AZURE_CONFIG_STORE = "AzureConfigService";
     private static final String ENV_MSI_ENDPOINT = "MSI_ENDPOINT";
     private static final String ENV_MSI_SECRET = "MSI_SECRET";
@@ -42,20 +45,24 @@ public class AzureConfigBootstrapConfiguration {
         ConnectionStringPool pool = new ConnectionStringPool();
         List<ConfigStore> stores = properties.getStores();
 
-        if (!properties.isMsiEnabled()) {
-            // Initialize connection string pool directly if MSI not enabled.
-            stores.forEach(store -> pool.put(store.getName(), ConnectionString.of(store.getConnectionString())));
-        } else {
-            // Try load connection string from ARM if MSI enabled
-            stores.stream().forEach(store -> {
-                AzureConfigMSIConnector msiConnector = new AzureConfigMSIConnector(credentials, store.getName());
+        for (ConfigStore store : stores) {
+            if (StringUtils.hasText(store.getName()) && StringUtils.hasText(store.getConnectionString())) {
+                pool.put(store.getName(), ConnectionString.of(store.getConnectionString()));
+            } else if (StringUtils.hasText(store.getName())) {
+                // Try load connection string from ARM if connection string is not configured
+                LOGGER.info("Load connection string for store [{}] from Azure Resource Management, " +
+                        "Azure managed identity should be enabled.", store.getName());
+                AzureResourceManagerConnector armConnector = new AzureResourceManagerConnector(credentials,
+                        store.getName());
 
-                String connectionString = msiConnector.getConnectionString();
+                String connectionString = armConnector.getConnectionString();
                 Assert.hasText(connectionString, "Connection string cannot be empty");
 
                 pool.put(store.getName(), ConnectionString.of(connectionString));
-            });
+            }
         }
+
+        Assert.notEmpty(pool.getAll(), "Connection string pool for the configuration stores is empty");
 
         return pool;
     }
@@ -67,7 +74,7 @@ public class AzureConfigBootstrapConfiguration {
             return new AppServiceMSICredentials(AzureEnvironment.AZURE);
         }
 
-        AzureCloudConfigMSIProperties msiProps = properties.getMsi();
+        AzureManagedIdentityProperties msiProps = properties.getManagedIdentity();
         MSICredentials credentials = new MSICredentials();
         if (msiProps != null && msiProps.getClientId() != null) {
             credentials.withClientId(msiProps.getClientId());

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/AzureManagedIdentityProperties.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/AzureManagedIdentityProperties.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the project root for
  * license information.
  */
-package com.microsoft.azure.spring.cloud.config.msi;
+package com.microsoft.azure.spring.cloud.config.managed.identity;
 
 import org.springframework.lang.Nullable;
 
@@ -13,7 +13,7 @@ import org.springframework.lang.Nullable;
  * @see <a href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http">Get a token using HTTP<a/>
  * </pre>
  */
-public class AzureCloudConfigMSIProperties {
+public class AzureManagedIdentityProperties {
     @Nullable
     private String objectId; // Optional: object_id of the managed identity
 

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/ConfigAccessKeyResource.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/ConfigAccessKeyResource.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the project root for
  * license information.
  */
-package com.microsoft.azure.spring.cloud.config.msi;
+package com.microsoft.azure.spring.cloud.config.managed.identity;
 
 import org.springframework.util.Assert;
 

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/ConfigAccessKeys.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/ConfigAccessKeys.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the project root for
  * license information.
  */
-package com.microsoft.azure.spring.cloud.config.msi;
+package com.microsoft.azure.spring.cloud.config.managed.identity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/ConfigResourceManager.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/managed/identity/ConfigResourceManager.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the project root for
  * license information.
  */
-package com.microsoft.azure.spring.cloud.config.msi;
+package com.microsoft.azure.spring.cloud.config.managed.identity;
 
 import com.microsoft.azure.credentials.AzureTokenCredentials;
 import com.microsoft.azure.management.Azure;

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigPropertiesTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/AzureCloudConfigPropertiesTest.java
@@ -115,18 +115,6 @@ public class AzureCloudConfigPropertiesTest {
         });
     }
 
-    @Test
-    public void msiNotEnabledValidStoreHasToBeConfigured() {
-        this.contextRunner.withPropertyValues(propPair(MSI_ENABLED_PROP, "false")).run(context -> {
-            assertThat(context).getFailure().hasStackTraceContaining("At least one config store has to be configured");
-        });
-
-        this.contextRunner.withPropertyValues(propPair(MSI_ENABLED_PROP, "false"),
-                propPair(STORE_NAME_PROP, TEST_STORE_NAME)).run(context -> {
-            assertThat(context).getFailure().hasStackTraceContaining("Connection string cannot be empty");
-        });
-    }
-
     private void assertInvalidField(AssertableApplicationContext context, String fieldName) {
         assertThat(context).getFailure().hasCauseInstanceOf(ConfigurationPropertiesBindException.class);
         assertThat(context).getFailure()

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigResourceManagerTest.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigResourceManagerTest.java
@@ -14,7 +14,7 @@ import com.microsoft.azure.management.resources.GenericResource;
 import com.microsoft.azure.management.resources.GenericResources;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azure.management.resources.Subscriptions;
-import com.microsoft.azure.spring.cloud.config.msi.ConfigResourceManager;
+import com.microsoft.azure.spring.cloud.config.managed.identity.ConfigResourceManager;
 import com.microsoft.azure.spring.cloud.context.core.util.Tuple;
 import com.microsoft.rest.RestException;
 import org.junit.Before;

--- a/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
+++ b/spring-cloud-azure-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestConstants.java
@@ -24,7 +24,6 @@ public class TestConstants {
     public static final String CONFIG_ENABLED_PROP = "spring.cloud.azure.config.enabled";
     public static final String WATCH_ENABLED_PROP = "spring.cloud.azure.config.watch.enabled";
     public static final String SEPARATOR_PROP = "spring.cloud.azure.config.profile-separator";
-    public static final String MSI_ENABLED_PROP = "spring.cloud.azure.config.msi-enabled";
 
     public static final String TEST_CONN_STRING =
             "Endpoint=https://fake.test.config.io;Id=fake-conn-id;Secret=ZmFrZS1jb25uLXNlY3JldA==";
@@ -35,7 +34,7 @@ public class TestConstants {
     public static final String TEST_ID = "fake-conn-id";
     public static final String TEST_SECRET = "ZmFrZS1jb25uLXNlY3JldA=="; // Base64 encoded from fake-conn-secret
 
-    public static final String MSI_TOKEN = "fake_token";
+    public static final String TEST_ACCESS_TOKEN = "fake_token";
 
     public static final String TEST_CONTEXT = "/foo/";
     public static final String TEST_KEY_1 = "test_key_1";

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-config/README.md
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-config/README.md
@@ -33,20 +33,19 @@ spring.cloud.azure.config.default-context | Default context path to load propert
 spring.cloud.azure.config.name | Alternative to Spring application name, if not configured, fallback to default Spring application name | No | ${spring.application.name}
 spring.cloud.azure.config.profile-separator | Profile separator for the key name, e.g., /foo-app_dev/db.connection.key, must follow format `^[a-zA-Z0-9_@]+$` | No | `_`
 spring.cloud.azure.config.fail-fast | Whether throw RuntimeException or not when exception occurs | No |  true
-spring.cloud.azure.config.msi-enabled | Whether load connection string from [Azure Resource Manager](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview) with [managed service identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) token or not | No | false
 spring.cloud.azure.config.watch.enabled | Whether enable watch feature or not | No | true
 spring.cloud.azure.config.watch.delay | Delay in milli-seconds between each watch schedule | No | 1000ms
-spring.cloud.azure.config.msi.client-id | Client id of the managed identity | No | null
-spring.cloud.azure.config.msi.object-id | Object id of the managed identity | No | null
+spring.cloud.azure.config.managed-identity.client-id | Client id of the user assigned managed identity, only required when choosing to use user assigned managed identity on Azure | No | null
+spring.cloud.azure.config.managed-identity.object-id | Object id of the user assigned managed identity, only required when choosing to use user assigned managed identity on Azure | No | null
 
 
 `spring.cloud.azure.config.stores` is a List of stores, for each store should follow below format:
 
 Name | Description | Required | Default 
 ---|---|---|---
-spring.cloud.azure.config.stores[0].name | Required when `spring.cloud.azure.config.msi-enabled` is true, name of the configuration store | Conditional | null
+spring.cloud.azure.config.stores[0].name | Name of the configuration store, required when `connection-string` is empty. If `connection-string` is empty and application is deployed on Azure VM or App Service with managed identity enabled, will try to load `connection-string` from Azure Resource Management. | Conditional | null
 spring.cloud.azure.config.stores[0].prefix | The prefix of the key name in the configuration store, e.g., /my-prefix/application/key.name | No |  null
-spring.cloud.azure.config.stores[0].connection-string | Required when `spring.cloud.azure.config.msi-enabled` is false, otherwise, can be loaded automatically on Azure Virtual Machine or App Service | Conditional | null
+spring.cloud.azure.config.stores[0].connection-string | Required when `name` is empty, otherwise, can be loaded automatically on Azure Virtual Machine or App Service | Conditional | null
 spring.cloud.azure.config.stores[0].label | Comma separated list of label values | No |  null
 
 
@@ -99,9 +98,10 @@ Follow below steps to enable managed service identity feature:
 
 1. [Enable managed identities service](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-can-i-use-managed-identities-for-azure-resources) for virtual machine or App Service, on which the application will be deployed
 
-2. Configure bootstrap.properties(or .yaml) in the Spring Boot application as following:
+2. Configure the [Azure RBAC](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) to allow application running on VM or App Service to access the configuration store. 
+ 
+3. Configure bootstrap.properties(or .yaml) in the Spring Boot application as following:
 ```
-spring.cloud.azure.config.msi-enabled=true
-spring.cloud.azure.config.stores[0].name=[msi-enabled-store-name]
+spring.cloud.azure.config.stores[0].name=[config-store-name]
 ```
-The configuration store name must be configured when msi-enabled is true, the connection string for the configuration store will be loaded automatically.
+The configuration store name must be configured when `connection-string` is empty, the connection string for the configuration store will be loaded automatically.


### PR DESCRIPTION
1. Remove `spring.cloud.azure.config.msi-enabled` property and try to retrieve connection-string from ARM automatically when connection-string is not configured.

2. Rename msi to managed identity.