### PR TITLE
sleep and retry when too many requests response received

### DIFF
--- a/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
+++ b/spring-cloud-azure-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigServiceTemplate.java
@@ -64,8 +64,8 @@ public class ConfigServiceTemplate implements ConfigServiceOperations {
         CloseableHttpResponse response = null;
         try {
             while ((response = getRawResponse(requestUri, connString)) != null) {
-                if (needRetry(response)) {
-                    sleep(response);
+                if (isThrottled(response)) {
+                    throttleOnResponse(response);
                     continue;
                 }
 
@@ -100,11 +100,11 @@ public class ConfigServiceTemplate implements ConfigServiceOperations {
         return result;
     }
 
-    private boolean needRetry(@NonNull CloseableHttpResponse response) {
+    private boolean isThrottled(@NonNull CloseableHttpResponse response) {
         return response.getStatusLine().getStatusCode() == TOO_MANY_REQ_CODE;
     }
 
-    private void sleep(@NonNull CloseableHttpResponse response) {
+    private void throttleOnResponse(@NonNull CloseableHttpResponse response) {
         Header retryHeader = response.getFirstHeader(RETRY_AFTER_MS_HEADER);
         if (retryHeader == null || Long.valueOf(retryHeader.getValue()) <= 0) {
             return;


### PR DESCRIPTION
Config service has requests throttling, if too many requests are sent, will receive response:
```
HTTP/1.1 429 Too Many Requests
retry-after-ms: 10
```

This PR will sleep for `retry-after-ms` milli-seconds and run the request again.