### PR TITLE
only one key pattern or multiple specific keys are supported

### DIFF
--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-config/README.md
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-config/README.md
@@ -84,7 +84,7 @@ Change certain property key in the configuration store on Azure Portal, e.g., /a
 INFO 17496 --- [TaskScheduler-1] o.s.c.e.event.RefreshEventListener       : Refresh keys changed: [config.message]
 ```
 The application now will be using the updated properties. By default, `@ConfigurationProperties` annotated beans will be automatically refreshed. Use `@RefreshScope` on beans which are required to be refreshed when properties are changed.
-By default, all the keys in a configuration store matching configured application name and prefix will be watched. To prevent configuration changes are picked up in the middle of an update of multiple keys, you are recommended to use the watched-key property to watch a specific key that signals the completion of your update so all configuration changes can be refreshed together.
+By default, all the keys in a configuration store will be watched. To prevent configuration changes are picked up in the middle of an update of multiple keys, you are recommended to use the watched-key property to watch a specific key that signals the completion of your update so all configuration changes can be refreshed together.
 ```
 spring.cloud.azure.config.stores[0].watched-key=[my-watched-key]
 ```


### PR DESCRIPTION
Prevously, with below configuration:
```
spring.cloud.azure.config.watch.enabled=true
spring.application.name=foo
```

Watch feature will query revisions API with key query param: `key=/foo/*,/application/*`, but the config store service does **not support** `key=/foo/*,/application/*`, only supports `key=/foo/*` or `key=abc,xyz`.