### PR TITLE
Add test logback configuration in config module

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/test/resources/logback-test.xml
+++ b/spring-cloud-azure-appconfiguration-config/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="warn">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>


### PR DESCRIPTION
To avoid printing too many DEBUG level logs by default which fails travis-ci.
