### PR TITLE
Rename snapshot version to be picked up by shields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>spring-cloud-azure</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Spring Cloud Azure</name>
     <description>Spring Cloud Azure</description>

--- a/spring-cloud-azure-appconfiguration-config/pom.xml
+++ b/spring-cloud-azure-appconfiguration-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-azure-autoconfigure/pom.xml
+++ b/spring-cloud-azure-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-azure-context/pom.xml
+++ b/spring-cloud-azure-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-azure-dependencies/pom.xml
+++ b/spring-cloud-azure-dependencies/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>spring-cloud-azure-dependencies</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Spring Cloud Azure dependencies BOM</name>
     <description>BOM for Spring Cloud Azure dependencies</description>

--- a/spring-cloud-azure-keyvault-config/pom.xml
+++ b/spring-cloud-azure-keyvault-config/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>spring-cloud-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-messaging/pom.xml
+++ b/spring-cloud-azure-messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-azure-samples/azure-appconfiguration-sample/pom.xml
+++ b/spring-cloud-azure-samples/azure-appconfiguration-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/azure-messaging-sample/pom.xml
+++ b/spring-cloud-azure-samples/azure-messaging-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/cache-sample/pom.xml
+++ b/spring-cloud-azure-samples/cache-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/eventhubs-binder-sample/pom.xml
+++ b/spring-cloud-azure-samples/eventhubs-binder-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/eventhubs-integration-sample/pom.xml
+++ b/spring-cloud-azure-samples/eventhubs-integration-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/eventhubs-kafka-sample/pom.xml
+++ b/spring-cloud-azure-samples/eventhubs-kafka-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/eventhubs-operation-sample/pom.xml
+++ b/spring-cloud-azure-samples/eventhubs-operation-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/pom.xml
+++ b/spring-cloud-azure-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/servicebus-integration-sample/pom.xml
+++ b/spring-cloud-azure-samples/servicebus-integration-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/servicebus-operation-sample/pom.xml
+++ b/spring-cloud-azure-samples/servicebus-operation-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/servicebus-queue-binder-sample/pom.xml
+++ b/spring-cloud-azure-samples/servicebus-queue-binder-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/servicebus-topic-binder-sample/pom.xml
+++ b/spring-cloud-azure-samples/servicebus-topic-binder-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/storage-queue-integration-sample/pom.xml
+++ b/spring-cloud-azure-samples/storage-queue-integration-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/storage-queue-operation-sample/pom.xml
+++ b/spring-cloud-azure-samples/storage-queue-operation-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-samples/storage-resource-sample/pom.xml
+++ b/spring-cloud-azure-samples/storage-resource-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-samples</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/pom.xml
+++ b/spring-cloud-azure-starters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-appconfiguration-config/pom.xml
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-appconfiguration-config/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-eventhubs-kafka/pom.xml
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-eventhubs-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-eventhubs/pom.xml
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-eventhubs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-keyvault-config/pom.xml
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-keyvault-config/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-servicebus/pom.xml
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-servicebus/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-storage-queue/pom.xml
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-storage-queue/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-starter-azure-cache/pom.xml
+++ b/spring-cloud-azure-starters/spring-starter-azure-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-starters/spring-starter-azure-storage/pom.xml
+++ b/spring-cloud-azure-starters/spring-starter-azure-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure-starters</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-storage/pom.xml
+++ b/spring-cloud-azure-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-stream-binder/pom.xml
+++ b/spring-cloud-azure-stream-binder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-eventhubs-stream-binder/pom.xml
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-eventhubs-stream-binder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure-stream-binder</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/pom.xml
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure-stream-binder</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/pom.xml
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure-stream-binder</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/pom.xml
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure-stream-binder</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-stream-binder-test/pom.xml
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-stream-binder-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure-stream-binder</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-integration-azure/pom.xml
+++ b/spring-integration-azure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-azure</artifactId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-integration-azure/spring-integration-azure-core/pom.xml
+++ b/spring-integration-azure/spring-integration-azure-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-integration-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-integration-azure/spring-integration-azure-test/pom.xml
+++ b/spring-integration-azure/spring-integration-azure-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-integration-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-integration-azure/spring-integration-eventhubs/pom.xml
+++ b/spring-integration-azure/spring-integration-eventhubs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-integration-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>spring-integration-azure-test</artifactId>
-            <version>1.0.0.BUILD-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-integration-azure/spring-integration-servicebus/pom.xml
+++ b/spring-integration-azure/spring-integration-servicebus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-integration-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>spring-integration-azure-test</artifactId>
-            <version>1.0.0.BUILD-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-integration-azure/spring-integration-storage-queue/pom.xml
+++ b/spring-integration-azure/spring-integration-storage-queue/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-integration-azure</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>spring-integration-azure-test</artifactId>
-            <version>1.0.0.BUILD-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The https://img.shields.io will return invalid response data when the version format is x.y.z.BUILD-SNAPSHOT. https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8905