### PR TITLE
Fix bug of event hub binder connecting to multiple binders

### DIFF
--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-eventhubs-stream-binder/src/main/java/com/microsoft/azure/eventhub/stream/binder/config/EventHubBinderConfiguration.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-eventhubs-stream-binder/src/main/java/com/microsoft/azure/eventhub/stream/binder/config/EventHubBinderConfiguration.java
@@ -10,6 +10,8 @@ import com.microsoft.azure.eventhub.stream.binder.EventHubMessageChannelBinder;
 import com.microsoft.azure.eventhub.stream.binder.properties.EventHubExtendedBindingProperties;
 import com.microsoft.azure.eventhub.stream.binder.provisioning.EventHubChannelProvisioner;
 import com.microsoft.azure.eventhub.stream.binder.provisioning.EventHubChannelResourceManagerProvisioner;
+import com.microsoft.azure.spring.cloud.autoconfigure.context.AzureEnvironmentAutoConfiguration;
+import com.microsoft.azure.spring.cloud.autoconfigure.eventhub.AzureEventHubAutoConfiguration;
 import com.microsoft.azure.spring.cloud.autoconfigure.eventhub.AzureEventHubProperties;
 import com.microsoft.azure.spring.cloud.autoconfigure.eventhub.EventHubUtils;
 import com.microsoft.azure.spring.cloud.autoconfigure.telemetry.TelemetryCollector;
@@ -21,6 +23,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
 
@@ -29,6 +32,7 @@ import javax.annotation.PostConstruct;
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
+@Import({AzureEventHubAutoConfiguration.class, AzureEnvironmentAutoConfiguration.class})
 @EnableConfigurationProperties({AzureEventHubProperties.class, EventHubExtendedBindingProperties.class})
 public class EventHubBinderConfiguration {
 


### PR DESCRIPTION
```
# Default binder
spring.cloud.azure.eventhub.connection-string=[]
spring.cloud.azure.eventhub.checkpoint-storage-account=[]
spring.cloud.azure.eventhub.checkpoint-access-key=[]

# Leaving this empty will use the default binder
# spring.cloud.stream.bindings.input.binder=azure1

# Another binder for azure1
spring.cloud.stream.binders.azure1.type=eventhub
spring.cloud.stream.binders.azure1.environment.spring.cloud.azure.eventhub.connection-string=[]
spring.cloud.stream.binders.azure1.environment.spring.cloud.azure.eventhub.checkpoint-storage-account=[]
spring.cloud.stream.binders.azure1.spring.cloud.azure.eventhub.checkpoint-access-key=[]

spring.cloud.stream.bindings.input.destination=eventhub1
spring.cloud.stream.bindings.input.binder=azure1
spring.cloud.stream.bindings.output.destination=eventhub1
spring.cloud.stream.bindings.output.binder=azure1
```