### PR TITLE
Fix custom header not added in Service Bus Message

### DIFF
--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/config/ServiceBusQueueBinderConfiguration.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/config/ServiceBusQueueBinderConfiguration.java
@@ -7,11 +7,12 @@
 package com.microsoft.azure.servicebus.stream.binder.config;
 
 import com.microsoft.azure.servicebus.stream.binder.ServiceBusQueueMessageChannelBinder;
-import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusExtendedBindingProperties;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusQueueExtendedBindingProperties;
 import com.microsoft.azure.servicebus.stream.binder.provisioning.ServiceBusChannelProvisioner;
 import com.microsoft.azure.servicebus.stream.binder.provisioning.ServiceBusQueueChannelResourceManagerProvisioner;
+import com.microsoft.azure.spring.cloud.autoconfigure.context.AzureEnvironmentAutoConfiguration;
 import com.microsoft.azure.spring.cloud.autoconfigure.servicebus.AzureServiceBusProperties;
+import com.microsoft.azure.spring.cloud.autoconfigure.servicebus.AzureServiceBusQueueAutoConfiguration;
 import com.microsoft.azure.spring.cloud.autoconfigure.servicebus.ServiceBusUtils;
 import com.microsoft.azure.spring.cloud.autoconfigure.telemetry.TelemetryCollector;
 import com.microsoft.azure.spring.cloud.context.core.api.ResourceManagerProvider;
@@ -23,6 +24,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
 
@@ -31,6 +33,7 @@ import javax.annotation.PostConstruct;
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
+@Import({AzureServiceBusQueueAutoConfiguration.class, AzureEnvironmentAutoConfiguration.class})
 @EnableConfigurationProperties({AzureServiceBusProperties.class, ServiceBusQueueExtendedBindingProperties.class})
 public class ServiceBusQueueBinderConfiguration {
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/config/ServiceBusTopicBinderConfiguration.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/config/ServiceBusTopicBinderConfiguration.java
@@ -26,6 +26,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import javax.annotation.PostConstruct;
+
 /**
  * @author Warren Zhu
  */

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/config/ServiceBusTopicBinderConfiguration.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/config/ServiceBusTopicBinderConfiguration.java
@@ -7,11 +7,12 @@
 package com.microsoft.azure.servicebus.stream.binder.config;
 
 import com.microsoft.azure.servicebus.stream.binder.ServiceBusTopicMessageChannelBinder;
-import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusExtendedBindingProperties;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusTopicExtendedBindingProperties;
 import com.microsoft.azure.servicebus.stream.binder.provisioning.ServiceBusChannelProvisioner;
 import com.microsoft.azure.servicebus.stream.binder.provisioning.ServiceBusTopicChannelResourceManagerProvisioner;
+import com.microsoft.azure.spring.cloud.autoconfigure.context.AzureEnvironmentAutoConfiguration;
 import com.microsoft.azure.spring.cloud.autoconfigure.servicebus.AzureServiceBusProperties;
+import com.microsoft.azure.spring.cloud.autoconfigure.servicebus.AzureServiceBusTopicAutoConfiguration;
 import com.microsoft.azure.spring.cloud.autoconfigure.servicebus.ServiceBusUtils;
 import com.microsoft.azure.spring.cloud.autoconfigure.telemetry.TelemetryCollector;
 import com.microsoft.azure.spring.cloud.context.core.api.ResourceManagerProvider;
@@ -23,14 +24,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import javax.annotation.PostConstruct;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Warren Zhu
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
+@Import({AzureServiceBusTopicAutoConfiguration.class, AzureEnvironmentAutoConfiguration.class})
 @EnableConfigurationProperties({AzureServiceBusProperties.class, ServiceBusTopicExtendedBindingProperties.class})
 public class ServiceBusTopicBinderConfiguration {
 

--- a/spring-integration-azure/spring-integration-azure-test/src/main/java/com/microsoft/azure/spring/integration/test/support/AzureMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-azure-test/src/main/java/com/microsoft/azure/spring/integration/test/support/AzureMessageConverterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class AzureMessageConverterTest<T> {
     protected String payload = "payload";
+    protected String headerProperties = "headerProperties";
     private AzureMessageConverter<T> converter;
     private Class<T> targetClass;
 
@@ -50,7 +51,7 @@ public abstract class AzureMessageConverterTest<T> {
     }
 
     private <U> void convertAndBack(U payload, Class<U> payloadClass) {
-        Message<U> message = MessageBuilder.withPayload(payload).build();
+        Message<U> message = MessageBuilder.withPayload(payload).setHeader(headerProperties, headerProperties).build();
         T azureMessage = converter.fromMessage(message, targetClass);
         Message<U> convertedMessage = converter.toMessage(azureMessage, payloadClass);
         assertMessagePayloadEquals(convertedMessage.getPayload(), payload);

--- a/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/converter/ServiceBusMessageConverter.java
+++ b/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/converter/ServiceBusMessageConverter.java
@@ -66,6 +66,8 @@ public class ServiceBusMessageConverter extends AbstractAzureMessageConverter<IM
         if (headers.containsKey(MessageHeaders.REPLY_CHANNEL)) {
             serviceBusMessage.setReplyTo(headers.get(MessageHeaders.REPLY_CHANNEL, String.class));
         }
+
+        headers.entrySet().forEach(e->serviceBusMessage.getProperties().put(e.getKey(), e.getValue().toString()));
     }
 
     @Override
@@ -89,6 +91,8 @@ public class ServiceBusMessageConverter extends AbstractAzureMessageConverter<IM
         if (StringUtils.hasText(serviceBusMessage.getReplyTo())) {
             headers.put(MessageHeaders.REPLY_CHANNEL, serviceBusMessage.getReplyTo());
         }
+
+        headers.putAll(serviceBusMessage.getProperties());
 
         return Collections.unmodifiableMap(headers);
     }

--- a/spring-integration-azure/spring-integration-servicebus/src/test/java/com/microsoft/azure/spring/integration/servicebus/ServiceBusMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-servicebus/src/test/java/com/microsoft/azure/spring/integration/servicebus/ServiceBusMessageConverterTest.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.spring.integration.test.support.AzureMessageConverter
 import org.springframework.messaging.MessageHeaders;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ServiceBusMessageConverterTest extends AzureMessageConverterTest<IMessage> {
     @Override
@@ -33,11 +34,15 @@ public class ServiceBusMessageConverterTest extends AzureMessageConverterTest<IM
     }
 
     protected void assertMessageHeadersEqual(IMessage serviceBusMessage,
-            org.springframework.messaging.Message<?> message) {
+                                             org.springframework.messaging.Message<?> message) {
         assertEquals(serviceBusMessage.getMessageId(), message.getHeaders().get(AzureHeaders.RAW_ID));
         assertEquals(serviceBusMessage.getContentType(),
                 message.getHeaders().get(MessageHeaders.CONTENT_TYPE, String.class));
         assertEquals(serviceBusMessage.getReplyTo(),
                 message.getHeaders().get(MessageHeaders.REPLY_CHANNEL, String.class));
+        assertNotNull(serviceBusMessage.getProperties().get(headerProperties));
+        assertNotNull(message.getHeaders().get(headerProperties, String.class));
+        assertEquals(serviceBusMessage.getProperties().get(headerProperties),
+                message.getHeaders().get(headerProperties, String.class));
     }
 }


### PR DESCRIPTION
## Description
When i want to add some properties in header using spring streaming Message, i found that producer can set the properties successfully, but the header properties can not be got in consumer. I have fixed this bug. Could you please review and accept it? Many thanks! 

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test
Steps to test code change
