### PR TITLE
Adding UUID to App Configuration requests

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
@@ -69,6 +69,17 @@ public class ConfigHttpClient {
         return httpClient.execute(request);
     }
 
+    /**
+     * Generates a request Header with a date, client request id, and a sha256 content hash.
+     * 
+     * @param request the request that will be sent with this header and will have a hash generated for it.
+     * @param date the current date and time
+     * @param credential HMAC-SHA256 Credential
+     * @param secret Key to encode HMAC
+     * @return map of the header values and keys
+     * @throws URISyntaxException will be thrown when the request URI isn't valid
+     * @throws IOException will be thrown when request content fails to convert to UTF-8
+     */
     private static Map<String, String> buildRequestHeaders(HttpUriRequest request, Date date, String credential,
             String secret) throws URISyntaxException, IOException {
         String requestTime = GMT_DATE_FORMAT.format(date);
@@ -83,6 +94,7 @@ public class ConfigHttpClient {
         // Compose headers
         Map<String, String> headers = new HashMap<>();
         headers.put("x-ms-date", requestTime);
+        headers.put("x-ms-client-request-id", UUID.randomUUID().toString());
         headers.put("x-ms-content-sha256", contentHash);
 
         String authorization = String.format("HMAC-SHA256 Credential=%s, SignedHeaders=%s, Signature=%s",

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
@@ -5,6 +5,23 @@
  */
 package com.microsoft.azure.spring.cloud.config;
 
+import static org.apache.commons.codec.digest.HmacAlgorithms.HMAC_SHA_256;
+import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
@@ -21,21 +38,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import static org.apache.commons.codec.digest.HmacAlgorithms.HMAC_SHA_256;
-import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
-
 /**
  * Util class to execute http request, before sending http request, valid request headers
  * will be added for each request based on given credential ID and secret.
- *
+ * 
  * How to use:
  * <p>
  * HttpGet httpGet = new HttpGet("https://my-config-store.azconfig.io/keys");

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClient.java
@@ -39,7 +39,8 @@ import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
  * How to use:
  * <p>
  * HttpGet httpGet = new HttpGet("https://my-config-store.azconfig.io/keys");
- * CloseableHttpResponse response = ConfigHttpClient.execute(httpGet, "my-credential", "my-secret");
+ * CloseableHttpResponse response = ConfigHttpClient.execute(httpGet, "my-credential",
+ * "my-secret");
  * <p/>
  */
 public class ConfigHttpClient {
@@ -70,12 +71,14 @@ public class ConfigHttpClient {
     }
 
     /**
-     * Generates a request Header with a date, client request id, and a sha256 content hash.
+     * Generates request Headers; date, client request id, and a sha256 content
+     * hash.
      * 
-     * @param request the request that will be sent with this header and will have a hash generated for it.
+     * @param request the request that will be sent with this header and will have a hash
+     * generated for it.
      * @param date the current date and time
-     * @param credential HMAC-SHA256 Credential
-     * @param secret Key to encode HMAC
+     * @param credential Access key ID
+     * @param secret Access key value
      * @return map of the header values and keys
      * @throws URISyntaxException will be thrown when the request URI isn't valid
      * @throws IOException will be thrown when request content fails to convert to UTF-8
@@ -129,8 +132,8 @@ public class ConfigHttpClient {
         return encodeHmac(HMAC_SHA_256, decodedKey, toSign);
     }
 
-
-    // Extract request path and query params, e.g., https://example.com/abc?param=xyz -> /abc?param=xyz
+    // Extract request path and query params, e.g., https://example.com/abc?param=xyz ->
+    // /abc?param=xyz
     private static String getRequestPath(HttpRequest request) throws URISyntaxException {
         URIBuilder uri = new URIBuilder(request.getRequestLine().getUri());
         String scheme = uri.getScheme() + "://";

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClientTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClientTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClientTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClientTest.java
@@ -5,6 +5,28 @@
  */
 package com.microsoft.azure.spring.cloud.config;
 
+import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_ID;
+import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_KV_API;
+import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_SECRET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
+
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -14,49 +36,44 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_ID;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_KV_API;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_SECRET;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-@PrepareForTest(ConfigHttpClient.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ConfigHttpClient.class })
+@PowerMockIgnore({"javax.crypto.*", "com.sun.org.apache.xerces.*", "org.xml.*", "javax.xml.*", "org.mockito.*"})
 public class ConfigHttpClientTest {
     private static final String DATE_FORMAT = "EEE, d MMM yyyy HH:mm:ss z";
     private static final SimpleDateFormat GMT_DATE_FORMAT = new SimpleDateFormat(DATE_FORMAT);
     private static final String TEST_USER_AGENT = ConfigHttpClient.USER_AGENT;
 
     private static final String TEST_DATE_1 = "Mon, 19 Nov 2018 00:00:00 GMT";
+    private static final String CLIENT_REQUEST_ID_1 = "39bb45d6-d973-4224-8281-00834f09e0ac";
     private static final String CONTENT_HASH_1 = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
     // The signature is generated with body as empty string "", but not null string
     private static final String AUTH_HEADER_1 = "HMAC-SHA256 Credential=fake-conn-id, SignedHeaders=x-ms-date;host;" +
             "x-ms-content-sha256, Signature=D+oRT4KhIRHpCdLiahSwJmcWuHmvnaYjwAm0SAcHGqs=";
 
     private static final String TEST_DATE_2 = "Mon, 19 Nov 2018 12:00:00 GMT";
+    private static final String CLIENT_REQUEST_ID_2 = "139465da-d671-4c32-adee-2832d15bec62";
     private static final String CONTENT_HASH_2 = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
     private static final String AUTH_HEADER_2 = "HMAC-SHA256 Credential=fake-conn-id, SignedHeaders=x-ms-date;host;" +
             "x-ms-content-sha256, Signature=P1SJR6iQjGgDmoV8/utXdwFyj69nYpd1OLkH1B9xjl8=";
 
     private static final String TEST_DATE_3 = "Mon, 19 Nov 2018 18:00:00 GMT";
+    private static final String CLIENT_REQUEST_ID_3 = "d325fa85-b980-4532-a122-ef4dec652353";
     private static final String CONTENT_HASH_3 = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
     private static final String AUTH_HEADER_3 = "HMAC-SHA256 Credential=fake-conn-id, SignedHeaders=x-ms-date;host;" +
             "x-ms-content-sha256, Signature=llHdHiBSvwRQjCOTz77g59hksBqxtEo3aERgxIWS4Ns=";
 
     private static final String TEST_DATE_4 = "Mon, 19 Nov 2018 23:59:59 GMT";
+    private static final String CLIENT_REQUEST_ID_4 = "3695c623-a9dc-4f04-a0bc-0005ecbb57c4";
     private static final String CONTENT_HASH_4 = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
     private static final String AUTH_HEADER_4 = "HMAC-SHA256 Credential=fake-conn-id, SignedHeaders=x-ms-date;host;" +
             "x-ms-content-sha256, Signature=va31Qc4gkGyZsqmVU8UoKh85QsxnjeNx2G9uxM5hZq0=";
@@ -67,13 +84,22 @@ public class ConfigHttpClientTest {
     private static Date testDate2;
     private static Date testDate3;
     private static Date testDate4;
+    
+    private static UUID uuid1 = UUID.fromString(CLIENT_REQUEST_ID_1);
+    private static UUID uuid2 = UUID.fromString(CLIENT_REQUEST_ID_2);
+    private static UUID uuid3 = UUID.fromString(CLIENT_REQUEST_ID_3);
+    private static UUID uuid4 = UUID.fromString(CLIENT_REQUEST_ID_4);
 
     @BeforeClass
     public static void init() throws ParseException {
-        Map<String, String> reqHeaders1 = getReqHeaders(TEST_DATE_1, CONTENT_HASH_1, AUTH_HEADER_1);
-        Map<String, String> reqHeaders2 = getReqHeaders(TEST_DATE_2, CONTENT_HASH_2, AUTH_HEADER_2);
-        Map<String, String> reqHeaders3 = getReqHeaders(TEST_DATE_3, CONTENT_HASH_3, AUTH_HEADER_3);
-        Map<String, String> reqHeaders4 = getReqHeaders(TEST_DATE_4, CONTENT_HASH_4, AUTH_HEADER_4);
+        Map<String, String> reqHeaders1 = getReqHeaders(TEST_DATE_1, CLIENT_REQUEST_ID_1, CONTENT_HASH_1,
+                AUTH_HEADER_1);
+        Map<String, String> reqHeaders2 = getReqHeaders(TEST_DATE_2, CLIENT_REQUEST_ID_2, CONTENT_HASH_2,
+                AUTH_HEADER_2);
+        Map<String, String> reqHeaders3 = getReqHeaders(TEST_DATE_3, CLIENT_REQUEST_ID_3, CONTENT_HASH_3,
+                AUTH_HEADER_3);
+        Map<String, String> reqHeaders4 = getReqHeaders(TEST_DATE_4, CLIENT_REQUEST_ID_4, CONTENT_HASH_4,
+                AUTH_HEADER_4);
 
         GMT_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
         testDate1 = GMT_DATE_FORMAT.parse(TEST_DATE_1);
@@ -87,9 +113,11 @@ public class ConfigHttpClientTest {
         REQUEST_DATA_LIST.add(new TestRequestData(testDate4, TEST_DATE_4, reqHeaders4));
     }
 
-    private static Map<String, String> getReqHeaders(String date, String contentHash, String authorizationHeader) {
+    private static Map<String, String> getReqHeaders(String date, String uuid, String contentHash,
+            String authorizationHeader) {
         Map<String, String> reqHeaderMap = new HashMap<>();
         reqHeaderMap.put("x-ms-date", date);
+        reqHeaderMap.put("x-ms-client-request-id", uuid);
         reqHeaderMap.put("x-ms-content-sha256", contentHash);
         reqHeaderMap.put("Authorization", authorizationHeader);
         reqHeaderMap.put(HttpHeaders.USER_AGENT, TEST_USER_AGENT);
@@ -105,13 +133,17 @@ public class ConfigHttpClientTest {
     @Test
     public void testRequestHeadersForAuthConfigured() throws URISyntaxException, IOException {
         assertThat(REQUEST_DATA_LIST.size()).isEqualTo(4);
+        PowerMockito.mockStatic(UUID.class);
+        PowerMockito.when(UUID.randomUUID()).thenReturn(uuid1, uuid2, uuid3, uuid4);
         for (int index = 0; index < REQUEST_DATA_LIST.size(); index++) {
             TestRequestData reqData = REQUEST_DATA_LIST.get(index);
 
             CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+            
+            
             when(httpClient.execute(any())).thenAnswer(new Answer<CloseableHttpResponse>() {
                 @Override
-                public CloseableHttpResponse answer(InvocationOnMock invocation) throws Throwable{
+                public CloseableHttpResponse answer(InvocationOnMock invocation) throws Throwable {
                     Object[] args = invocation.getArguments();
                     HttpUriRequest request = (HttpUriRequest) args[0];
                     Header[] headers = request.getAllHeaders();
@@ -119,8 +151,9 @@ public class ConfigHttpClientTest {
                     Map<String, String> actualHeaderMap = new HashMap<>();
                     Arrays.stream(headers).forEach(h -> actualHeaderMap.put(h.getName(), h.getValue()));
 
-                    // Test the headers of the passed in request has been correctly configured before firing request.
-                    assertThat(reqData.reqHeaders.size()).isEqualTo(4);
+                    // Test the headers of the passed in request has been correctly
+                    // configured before firing request.
+                    assertThat(reqData.reqHeaders.size()).isEqualTo(5);
                     reqData.reqHeaders.forEach((k, v) -> {
                         assertThat(actualHeaderMap).containsEntry(k, v);
                     });
@@ -138,7 +171,9 @@ public class ConfigHttpClientTest {
 
     static class TestRequestData {
         private Date date;
+
         private String dateString;
+
         private Map<String, String> reqHeaders;
 
         public TestRequestData(Date date, String dateString, Map<String, String> reqHeaders) {
@@ -160,5 +195,3 @@ public class ConfigHttpClientTest {
         }
     }
 }
-
-

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClientTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/ConfigHttpClientTest.java
@@ -140,7 +140,6 @@ public class ConfigHttpClientTest {
 
             CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
             
-            
             when(httpClient.execute(any())).thenAnswer(new Answer<CloseableHttpResponse>() {
                 @Override
                 public CloseableHttpResponse answer(InvocationOnMock invocation) throws Throwable {


### PR DESCRIPTION
## Description
Added a new header onto App Configurations requests setting the x-ms-client-request-id.

## Related PRs
List related PRs against other branches: PR 4752955

## Steps to Test
Have a logback.xml file in your applications resource folder with the level set to DEBUG. When requests are made the UUID will be outputted to the applications logs, which can then be matched to an App Configuration log.