### PR TITLE
fix #542 : Reregister event hub consumer after unregister caused IllegalStateException

### DIFF
--- a/spring-cloud-azure-context/src/main/java/com/microsoft/azure/spring/cloud/context/core/util/Memoizer.java
+++ b/spring-cloud-azure-context/src/main/java/com/microsoft/azure/spring/cloud/context/core/util/Memoizer.java
@@ -34,4 +34,10 @@ public class Memoizer {
     public static <T, U, R> BiFunction<T, U, R> memoize(Map<Tuple<T, U>, R> map, BiFunction<T, U, R> biFunction) {
         return (t, u) -> map.computeIfAbsent(Tuple.of(t, u), (k) -> biFunction.apply(k.getFirst(), k.getSecond()));
     }
+    
+    public static <T, U, R> BiFunction<T, U, R> memoizeCompute
+      (Map<Tuple<T, U>, R> map, BiFunction<T, U, R> biFunction) {
+        return (t, u) -> map.compute(Tuple.of(t, u), (k, v) -> biFunction.apply(k.getFirst(), k.getSecond()));
+    }
+    
 }

--- a/spring-cloud-azure-context/src/test/java/com/microsoft/azure/spring/cloud/context/core/MemoizerTest.java
+++ b/spring-cloud-azure-context/src/test/java/com/microsoft/azure/spring/cloud/context/core/MemoizerTest.java
@@ -74,10 +74,10 @@ public class MemoizerTest {
         when(expensiveOperation.compute(INPUT, INPUT2)).thenReturn(OUTPUT);
         BiFunction<String, String, String> memoized = Memoizer.memoizeCompute(map, expensiveOperation::compute);
         Assert.assertEquals(memoized.apply(INPUT, INPUT2), OUTPUT);
-        verify(expensiveOperation, times(1)).compute(INPUT, INPUT2);
+        Assert.assertEquals(memoized.apply(INPUT, INPUT2), OUTPUT);
+        verify(expensiveOperation, times(2)).compute(INPUT, INPUT2);
         Assert.assertTrue(map.size() == 1);
     }
-
     interface ExpensiveOperation {
         String compute(String input);
     }

--- a/spring-cloud-azure-context/src/test/java/com/microsoft/azure/spring/cloud/context/core/MemoizerTest.java
+++ b/spring-cloud-azure-context/src/test/java/com/microsoft/azure/spring/cloud/context/core/MemoizerTest.java
@@ -66,6 +66,17 @@ public class MemoizerTest {
         verify(expensiveOperation, times(1)).compute(INPUT, INPUT2);
         Assert.assertTrue(map.size() == 1);
     }
+    
+    @Test
+    public void memoizeBiFuncWithMapCompute() {
+        Map<Tuple<String, String>, String> map = new ConcurrentHashMap<>();
+        ExpensiveBiOperation expensiveOperation = mock(ExpensiveBiOperation.class);
+        when(expensiveOperation.compute(INPUT, INPUT2)).thenReturn(OUTPUT);
+        BiFunction<String, String, String> memoized = Memoizer.memoizeCompute(map, expensiveOperation::compute);
+        Assert.assertEquals(memoized.apply(INPUT, INPUT2), OUTPUT);
+        verify(expensiveOperation, times(1)).compute(INPUT, INPUT2);
+        Assert.assertTrue(map.size() == 1);
+    }
 
     interface ExpensiveOperation {
         String compute(String input);

--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/api/EventHubClientFactory.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/api/EventHubClientFactory.java
@@ -21,4 +21,5 @@ public interface EventHubClientFactory {
 
     EventProcessorHost getOrCreateEventProcessorHost(String name, String consumerGroup);
 
+    EventProcessorHost makeEventProcessorHost(String name, String consumerGroup);
 }

--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/impl/AbstractEventHubTemplate.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/impl/AbstractEventHubTemplate.java
@@ -99,7 +99,7 @@ public class AbstractEventHubTemplate {
     }
 
     protected void register(String name, String consumerGroup, EventHubProcessor eventProcessor) {
-        EventProcessorHost host = this.clientFactory.getOrCreateEventProcessorHost(name, consumerGroup);
+        EventProcessorHost host = this.clientFactory.makeEventProcessorHost(name, consumerGroup);
         host.registerEventProcessorFactory(context -> eventProcessor, buildEventProcessorOptions(startPosition));
     }
 

--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/EventHubTemplateSubscribeTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/EventHubTemplateSubscribeTest.java
@@ -38,6 +38,8 @@ public class EventHubTemplateSubscribeTest extends SubscribeByGroupOperationTest
         future.complete(null);
         this.subscribeByGroupOperation = new EventHubTemplate(mockClientFactory);
         when(this.mockClientFactory.getOrCreateEventProcessorHost(anyString(), anyString())).thenReturn(this.host);
+        when(this.mockClientFactory.makeEventProcessorHost(anyString(), anyString())).thenReturn(this.host);
+        
         when(this.host
                 .registerEventProcessorFactory(isA(IEventProcessorFactory.class), isA(EventProcessorOptions.class)))
                 .thenReturn(future);
@@ -46,12 +48,12 @@ public class EventHubTemplateSubscribeTest extends SubscribeByGroupOperationTest
 
     @Override
     protected void verifySubscriberCreatorCalled() {
-        verify(this.mockClientFactory, atLeastOnce()).getOrCreateEventProcessorHost(anyString(), anyString());
+        verify(this.mockClientFactory, atLeastOnce()).makeEventProcessorHost(anyString(), anyString());
     }
 
     @Override
     protected void verifySubscriberCreatorNotCalled() {
-        verify(this.mockClientFactory, never()).getOrCreateEventProcessorHost(anyString(), anyString());
+        verify(this.mockClientFactory, never()).makeEventProcessorHost(anyString(), anyString());
     }
 
     @Override


### PR DESCRIPTION
## Description
fix #542 : Reregister event hub consumer after unregister caused IllegalStateException


## Related PRs

branch | PR

## Todos

Note:

Within  com.microsoft.azure.spring.integration.eventhub.impl.AbstractEventHubTemplate.unregister(String, String)

the method com.microsoft.azure.spring.integration.eventhub.api.EventHubClientFactory.getOrCreateEventProcessorHost(String, String) is called.

This implies that an existing or new instance of EventProcessorHost is retrieved.
But it seems very strange creating a new instance of EventProcessorHost during the **unregister** phase.


## Steps to Test

1. run  microservice using EventHub that starts all binders
2. using microservice, make all binders to go down 
3. after some while, using microservice, make all binders to go up