### PR TITLE
Reregister event hub consumer after unregister caused IllegalStateException

### DIFF
--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/api/EventHubClientFactory.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/api/EventHubClientFactory.java
@@ -6,12 +6,15 @@
 
 package com.microsoft.azure.spring.integration.eventhub.api;
 
+import java.util.Optional;
+
 import com.microsoft.azure.eventhubs.EventHubClient;
 import com.microsoft.azure.eventhubs.PartitionSender;
 import com.microsoft.azure.eventprocessorhost.EventProcessorHost;
 
 /**
  * @author Warren Zhu
+ * @author Domenico Sibilio
  */
 public interface EventHubClientFactory {
 
@@ -20,5 +23,9 @@ public interface EventHubClientFactory {
     PartitionSender getOrCreatePartitionSender(String eventhub, String partition);
 
     EventProcessorHost getOrCreateEventProcessorHost(String name, String consumerGroup);
+
+    Optional<EventProcessorHost> getEventProcessorHost(String name, String consumerGroup);
+
+    EventProcessorHost removeEventProcessorHost(String name, String consumerGroup);
 
 }

--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/EventHubTemplateSubscribeTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/EventHubTemplateSubscribeTest.java
@@ -6,6 +6,9 @@
 
 package com.microsoft.azure.spring.integration.eventhub;
 
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
 import com.microsoft.azure.eventprocessorhost.EventProcessorHost;
 import com.microsoft.azure.eventprocessorhost.EventProcessorOptions;
 import com.microsoft.azure.eventprocessorhost.IEventProcessorFactory;
@@ -18,9 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.concurrent.CompletableFuture;
-
-import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,6 +39,7 @@ public class EventHubTemplateSubscribeTest extends SubscribeByGroupOperationTest
         future.complete(null);
         this.subscribeByGroupOperation = new EventHubTemplate(mockClientFactory);
         when(this.mockClientFactory.getOrCreateEventProcessorHost(anyString(), anyString())).thenReturn(this.host);
+        when(this.mockClientFactory.getEventProcessorHost(anyString(), anyString())).thenReturn(Optional.of(this.host));
         when(this.host
                 .registerEventProcessorFactory(isA(IEventProcessorFactory.class), isA(EventProcessorOptions.class)))
                 .thenReturn(future);
@@ -62,6 +64,7 @@ public class EventHubTemplateSubscribeTest extends SubscribeByGroupOperationTest
 
     @Override
     protected void verifySubscriberUnregistered(int times) {
+        verify(this.mockClientFactory, times(times)).removeEventProcessorHost(anyString(), anyString());
         verify(this.host, times(times)).unregisterEventProcessor();
     }
 }


### PR DESCRIPTION
## Description
Fixes #542 : Reregister event hub consumer after unregister caused IllegalStateException

## Steps to Test
1. run a Java application that uses `spring-cloud-azure-eventhubs-stream-binder` - _this should start all binders_
2. programmatically stop all binders _(you can collect `BindingCreatedEvent` Spring events to collect all binders, and then stop each of them by invoking `stop()`)_
3. after a while, restart all binders _(by invoking `start()` on each previously stopped binder)_