### PR TITLE
Enable sessions #514

### DIFF
--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/readme.md
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/readme.md
@@ -98,3 +98,9 @@ Default: `1`
 Controls the max concurrent calls of service bus message handler and the size of fixed thread pool that handles user's business logic
 
 Default: `1`
+
+**_sessionEnabled_**
+
+Controls if is a session aware consumer. Set it to `true` if is a queue with sessions enabled.
+
+Default: `false`

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusQueueSessionsBinderTests.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusQueueSessionsBinderTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.servicebus.stream.binder;
+
+import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusConsumerProperties;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.HeaderMode;
+
+/**
+ * Test cases are defined in super class
+ *
+ * @author Eduardo Sciullo
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceBusQueueSessionsBinderTests extends
+        ServiceBusQueuePartitionBinderTests {
+
+    @Override
+    protected ExtendedConsumerProperties<ServiceBusConsumerProperties> createConsumerProperties() {
+
+        ServiceBusConsumerProperties serviceBusConsumerProperties = new ServiceBusConsumerProperties();
+        serviceBusConsumerProperties.setSessionsEnabled(true);
+
+        ExtendedConsumerProperties<ServiceBusConsumerProperties> properties = new ExtendedConsumerProperties<>(
+                serviceBusConsumerProperties);
+        properties.setHeaderMode(HeaderMode.embeddedHeaders);
+        return properties;
+    }
+
+}

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusMessageChannelBinder.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusMessageChannelBinder.java
@@ -23,10 +23,12 @@ import org.springframework.messaging.MessageHandler;
 
 /**
  * @author Warren Zhu
+ * @author Eduardo Sciullo
  */
 public abstract class ServiceBusMessageChannelBinder<T extends ServiceBusExtendedBindingProperties> extends
-        AbstractMessageChannelBinder<ExtendedConsumerProperties<ServiceBusConsumerProperties>,
-                ExtendedProducerProperties<ServiceBusProducerProperties>, ServiceBusChannelProvisioner>
+        AbstractMessageChannelBinder<ExtendedConsumerProperties<ServiceBusConsumerProperties>, 
+        ExtendedProducerProperties<ServiceBusProducerProperties>, 
+        ServiceBusChannelProvisioner>
         implements
         ExtendedPropertiesBinder<MessageChannel, ServiceBusConsumerProperties, ServiceBusProducerProperties> {
 
@@ -86,7 +88,8 @@ public abstract class ServiceBusMessageChannelBinder<T extends ServiceBusExtende
             ExtendedConsumerProperties<ServiceBusConsumerProperties> properties) {
         ServiceBusConsumerProperties consumerProperties = properties.getExtension();
         return ServiceBusClientConfig.builder().setPrefetchCount(consumerProperties.getPrefetchCount())
-                                     .setConcurrency(consumerProperties.getConcurrency()).build();
+                .setConcurrency(consumerProperties.getConcurrency())
+                .setSessionsEnabled(consumerProperties.isSessionsEnabled()).build();
     }
 
     abstract SendOperation getSendOperation();

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/src/main/java/com/microsoft/azure/servicebus/stream/binder/properties/ServiceBusConsumerProperties.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/src/main/java/com/microsoft/azure/servicebus/stream/binder/properties/ServiceBusConsumerProperties.java
@@ -10,10 +10,12 @@ import com.microsoft.azure.spring.integration.core.api.CheckpointMode;
 
 /**
  * @author Warren Zhu
+ * @author Eduardo Sciullo
  */
 public class ServiceBusConsumerProperties {
     private int prefetchCount = 1;
     private int concurrency = 1;
+    private boolean sessionsEnabled = false;
 
     private CheckpointMode checkpointMode = CheckpointMode.RECORD;
 
@@ -53,4 +55,20 @@ public class ServiceBusConsumerProperties {
     public void setConcurrency(int concurrency) {
         this.concurrency = concurrency;
     }
+
+    /**
+     * Controls if is session aware
+     *
+     * <p>
+     * Default : false
+     */
+    public boolean isSessionsEnabled() {
+        return sessionsEnabled;
+    }
+
+    public void setSessionsEnabled(boolean sessionsEnabled) {
+        this.sessionsEnabled = sessionsEnabled;
+    }
+    
+    
 }

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/readme.md
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/readme.md
@@ -99,3 +99,9 @@ Default: `1`
 Controls the max concurrent calls of service bus message handler and the size of fixed thread pool that handles user's business logic
 
 Default: `1`
+
+**_sessionEnabled_**
+
+Controls if is a session aware consumer. Set it to `true` if is a topic with sessions enabled.
+
+Default: `false`

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicSessionsBinderTests.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicSessionsBinderTests.java
@@ -26,7 +26,7 @@ public class ServiceBusTopicSessionsBinderTests extends
     protected ExtendedConsumerProperties<ServiceBusConsumerProperties> createConsumerProperties() {
 
         ServiceBusConsumerProperties serviceBusConsumerProperties = new ServiceBusConsumerProperties();
-        serviceBusConsumerProperties.setSessionEnabled(true);
+        serviceBusConsumerProperties.setSessionsEnabled(true);
 
         ExtendedConsumerProperties<ServiceBusConsumerProperties> properties = new ExtendedConsumerProperties<>(
                 serviceBusConsumerProperties);

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicSessionsBinderTests.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicSessionsBinderTests.java
@@ -6,25 +6,12 @@
 
 package com.microsoft.azure.servicebus.stream.binder;
 
-import com.microsoft.azure.servicebus.SubscriptionClient;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusConsumerProperties;
-import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusProducerProperties;
-import com.microsoft.azure.servicebus.stream.binder.test.AzurePartitionBinderTests;
-import com.microsoft.azure.spring.integration.servicebus.factory.ServiceBusTopicClientFactory;
-import com.microsoft.azure.spring.integration.servicebus.topic.support.ServiceBusTopicTestOperation;
-import org.junit.Before;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
-import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.HeaderMode;
-
-import java.util.concurrent.CompletableFuture;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  * Test cases are defined in super class
@@ -33,63 +20,18 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceBusTopicSessionsBinderTests extends
-        AzurePartitionBinderTests<ServiceBusTopicTestBinder, ExtendedConsumerProperties<ServiceBusConsumerProperties>,
-                ExtendedProducerProperties<ServiceBusProducerProperties>> {
-    @Mock
-    ServiceBusTopicClientFactory clientFactory;
-
-    @Mock
-    SubscriptionClient subscriptionClient;
-
-    private ServiceBusTopicTestBinder binder;
-
-    @Before
-    public void setUp() {
-        when(this.clientFactory.getOrCreateSubscriptionClient(anyString(), anyString()))
-                .thenReturn(this.subscriptionClient);
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        future.complete(null);
-        when(this.subscriptionClient.completeAsync(any())).thenReturn(future);
-        this.binder = new ServiceBusTopicTestBinder(new ServiceBusTopicTestOperation(this.clientFactory));
-    }
-
-    @Override
-    protected String getClassUnderTestName() {
-        return ServiceBusTopicTestBinder.class.getSimpleName();
-    }
-
-    @Override
-    protected ServiceBusTopicTestBinder getBinder() throws Exception {
-        return this.binder;
-    }
+        ServiceBusTopicPartitionBinderTests {
 
     @Override
     protected ExtendedConsumerProperties<ServiceBusConsumerProperties> createConsumerProperties() {
-        
-        ServiceBusConsumerProperties serviceBusConsumerProperties =  new ServiceBusConsumerProperties();
+
+        ServiceBusConsumerProperties serviceBusConsumerProperties = new ServiceBusConsumerProperties();
         serviceBusConsumerProperties.setSessionEnabled(true);
-        
-        ExtendedConsumerProperties<ServiceBusConsumerProperties> properties =
-                new ExtendedConsumerProperties<>(serviceBusConsumerProperties);
+
+        ExtendedConsumerProperties<ServiceBusConsumerProperties> properties = new ExtendedConsumerProperties<>(
+                serviceBusConsumerProperties);
         properties.setHeaderMode(HeaderMode.embeddedHeaders);
         return properties;
     }
 
-    @Override
-    protected ExtendedProducerProperties<ServiceBusProducerProperties> createProducerProperties() {
-        ExtendedProducerProperties<ServiceBusProducerProperties> properties =
-                new ExtendedProducerProperties<>(new ServiceBusProducerProperties());
-        properties.setHeaderMode(HeaderMode.embeddedHeaders);
-        return properties;
-    }
-
-    @Override
-    public void testOneRequiredGroup() {
-        // Required group test rely on unsupported start position of consumer properties
-    }
-
-    @Override
-    public void testTwoRequiredGroups() {
-        // Required group test rely on unsupported start position of consumer properties
-    }
 }

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicSessionsBinderTests.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/test/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicSessionsBinderTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.servicebus.stream.binder;
+
+import com.microsoft.azure.servicebus.SubscriptionClient;
+import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusConsumerProperties;
+import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusProducerProperties;
+import com.microsoft.azure.servicebus.stream.binder.test.AzurePartitionBinderTests;
+import com.microsoft.azure.spring.integration.servicebus.factory.ServiceBusTopicClientFactory;
+import com.microsoft.azure.spring.integration.servicebus.topic.support.ServiceBusTopicTestOperation;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.HeaderMode;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases are defined in super class
+ *
+ * @author Eduardo Sciullo
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceBusTopicSessionsBinderTests extends
+        AzurePartitionBinderTests<ServiceBusTopicTestBinder, ExtendedConsumerProperties<ServiceBusConsumerProperties>,
+                ExtendedProducerProperties<ServiceBusProducerProperties>> {
+    @Mock
+    ServiceBusTopicClientFactory clientFactory;
+
+    @Mock
+    SubscriptionClient subscriptionClient;
+
+    private ServiceBusTopicTestBinder binder;
+
+    @Before
+    public void setUp() {
+        when(this.clientFactory.getOrCreateSubscriptionClient(anyString(), anyString()))
+                .thenReturn(this.subscriptionClient);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        future.complete(null);
+        when(this.subscriptionClient.completeAsync(any())).thenReturn(future);
+        this.binder = new ServiceBusTopicTestBinder(new ServiceBusTopicTestOperation(this.clientFactory));
+    }
+
+    @Override
+    protected String getClassUnderTestName() {
+        return ServiceBusTopicTestBinder.class.getSimpleName();
+    }
+
+    @Override
+    protected ServiceBusTopicTestBinder getBinder() throws Exception {
+        return this.binder;
+    }
+
+    @Override
+    protected ExtendedConsumerProperties<ServiceBusConsumerProperties> createConsumerProperties() {
+        
+        ServiceBusConsumerProperties serviceBusConsumerProperties =  new ServiceBusConsumerProperties();
+        serviceBusConsumerProperties.setSessionEnabled(true);
+        
+        ExtendedConsumerProperties<ServiceBusConsumerProperties> properties =
+                new ExtendedConsumerProperties<>(serviceBusConsumerProperties);
+        properties.setHeaderMode(HeaderMode.embeddedHeaders);
+        return properties;
+    }
+
+    @Override
+    protected ExtendedProducerProperties<ServiceBusProducerProperties> createProducerProperties() {
+        ExtendedProducerProperties<ServiceBusProducerProperties> properties =
+                new ExtendedProducerProperties<>(new ServiceBusProducerProperties());
+        properties.setHeaderMode(HeaderMode.embeddedHeaders);
+        return properties;
+    }
+
+    @Override
+    public void testOneRequiredGroup() {
+        // Required group test rely on unsupported start position of consumer properties
+    }
+
+    @Override
+    public void testTwoRequiredGroups() {
+        // Required group test rely on unsupported start position of consumer properties
+    }
+}

--- a/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/ServiceBusClientConfig.java
+++ b/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/ServiceBusClientConfig.java
@@ -9,16 +9,21 @@ package com.microsoft.azure.spring.integration.servicebus;
  * Service bus client related config
  *
  * @author Warren Zhu
+ * @author Eduardo Sciullo
  */
 public class ServiceBusClientConfig {
 
     private final int prefetchCount;
 
     private final int concurrency;
-
-    private ServiceBusClientConfig(int prefetchCount, int concurrency) {
+    
+    private final boolean sessionsEnabled;
+    
+    private ServiceBusClientConfig(int prefetchCount, int concurrency, boolean sessionsEnabled) {
+        
         this.prefetchCount = prefetchCount;
         this.concurrency = concurrency;
+        this.sessionsEnabled = sessionsEnabled;
     }
 
     public int getPrefetchCount() {
@@ -27,6 +32,10 @@ public class ServiceBusClientConfig {
 
     public int getConcurrency() {
         return concurrency;
+    }       
+
+    public boolean isSessionsEnabled() {
+        return sessionsEnabled;
     }
 
     public static ServiceBusClientConfigBuilder builder(){
@@ -36,7 +45,8 @@ public class ServiceBusClientConfig {
     public static class ServiceBusClientConfigBuilder {
         private int prefetchCount = 1;
         private int concurrency = 1;
-
+        private boolean sessionsEnabled = false;
+        
         public ServiceBusClientConfigBuilder setPrefetchCount(int prefetchCount) {
             this.prefetchCount = prefetchCount;
             return this;
@@ -47,8 +57,13 @@ public class ServiceBusClientConfig {
             return this;
         }
 
+        public ServiceBusClientConfigBuilder setSessionsEnabled(boolean sessionsEnabled) {
+            this.sessionsEnabled = sessionsEnabled;
+            return this;
+        }
+        
         public ServiceBusClientConfig build() {
-            return new ServiceBusClientConfig(prefetchCount, concurrency);
+            return new ServiceBusClientConfig(prefetchCount, concurrency, sessionsEnabled);
         }
     }
 }


### PR DESCRIPTION
## Description
Enable the usage of Queue/Topic with sessions configuratively.

Implementation details:

- The QueueMessageHandler/TopicMessageHandler class implement also the ISessionHandler interface.
- Added property `spring.cloud.stream.servicebus.queue.bindings.input.consumer.sessionEnabled` (default value false)

## Todos
- [x] Tests
- [x] Documentation

## Steps to Test
Connect to a sessions enabled.
Configure `spring.cloud.stream.servicebus.queue.bindings.input.consumer.sessionEnabled=true`
