### PR TITLE
App Config Failure Change

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationAutoConfiguration.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationAutoConfiguration.java
@@ -14,22 +14,22 @@ import org.springframework.context.annotation.Configuration;
 import com.microsoft.azure.spring.cloud.config.stores.ClientStore;
 
 @Configuration
-@ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
-public class AzureCloudConfigAutoConfiguration {
+@ConditionalOnProperty(prefix = AppConfigurationProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
+public class AppConfigurationAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(RefreshEndpoint.class)
-    static class CloudWatchAutoConfiguration {
+    static class AppConfigurationWatchAutoConfiguration {
 
         @Bean
-        public AzureCloudConfigRefresh getConfigWatch(AzureCloudConfigProperties properties,
-                AzureConfigPropertySourceLocator sourceLocator, ClientStore clientStore) {
-            return new AzureCloudConfigRefresh(properties, sourceLocator.getStoreContextsMap(), clientStore);
+        public AppConfigurationRefresh getConfigWatch(AppConfigurationProperties properties,
+                AppConfigurationPropertySourceLocator sourceLocator, ClientStore clientStore) {
+            return new AppConfigurationRefresh(properties, sourceLocator.getStoreContextsMap(), clientStore);
         }
 
         @Bean
-        public ConfigListener configListener(AzureCloudConfigRefresh azureCloudConfigWatch) {
-            return new ConfigListener(azureCloudConfigWatch);
+        public ConfigListener configListener(AppConfigurationRefresh appConfigurationRefresh) {
+            return new ConfigListener(appConfigurationRefresh);
         }
     }
 }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationBootstrapConfiguration.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationBootstrapConfiguration.java
@@ -74,7 +74,7 @@ public class AppConfigurationBootstrapConfiguration {
         } catch (NoUniqueBeanDefinitionException e) {
             throw new RuntimeException("Failed to find unique KeyVaultCredentialProvider Bean for authentication.", e);
         } catch (NoSuchBeanDefinitionException e) {
-            LOGGER.info("No KeyVaultCredentialProvider found.");
+            LOGGER.debug("No KeyVaultCredentialProvider found.");
         }
         return new AppConfigurationPropertySourceLocator(properties, appProperties, clients,
                 keyVaultCredentialProvider);
@@ -90,7 +90,7 @@ public class AppConfigurationBootstrapConfiguration {
             throw new RuntimeException(
                     "Failed to find unique AppConfigurationCredentialProvider Bean for authentication.", e);
         } catch (NoSuchBeanDefinitionException e) {
-            LOGGER.info("No AppConfigurationCredentialProvider found.");
+            LOGGER.debug("No AppConfigurationCredentialProvider found.");
         }
         return new ClientStore(appProperties, pool, tokenCredentialProvider);
     }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationBootstrapConfiguration.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationBootstrapConfiguration.java
@@ -29,15 +29,15 @@ import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 import com.microsoft.azure.spring.cloud.context.core.config.AzureManagedIdentityProperties;
 
 @Configuration
-@EnableConfigurationProperties({ AzureCloudConfigProperties.class, AppConfigProviderProperties.class })
-@ConditionalOnClass(AzureConfigPropertySourceLocator.class)
-@ConditionalOnProperty(prefix = AzureCloudConfigProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
-public class AzureConfigBootstrapConfiguration {
+@EnableConfigurationProperties({ AppConfigurationProperties.class, AppConfigurationProviderProperties.class })
+@ConditionalOnClass(AppConfigurationPropertySourceLocator.class)
+@ConditionalOnProperty(prefix = AppConfigurationProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
+public class AppConfigurationBootstrapConfiguration {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AzureConfigBootstrapConfiguration.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppConfigurationBootstrapConfiguration.class);
 
     @Bean
-    public ConnectionPool initConnectionString(AzureCloudConfigProperties properties) {
+    public ConnectionPool initConnectionString(AppConfigurationProperties properties) {
         ConnectionPool pool = new ConnectionPool();
         List<ConfigStore> stores = properties.getStores();
 
@@ -66,35 +66,31 @@ public class AzureConfigBootstrapConfiguration {
     }
 
     @Bean
-    public AzureConfigPropertySourceLocator sourceLocator(AzureCloudConfigProperties properties,
-            AppConfigProviderProperties appProperties, ClientStore clients, ApplicationContext context) {
+    public AppConfigurationPropertySourceLocator sourceLocator(AppConfigurationProperties properties,
+            AppConfigurationProviderProperties appProperties, ClientStore clients, ApplicationContext context) {
         KeyVaultCredentialProvider keyVaultCredentialProvider = null;
         try {
             keyVaultCredentialProvider = context.getBean(KeyVaultCredentialProvider.class);
         } catch (NoUniqueBeanDefinitionException e) {
-            LOGGER.error("Failed to find unique TokenCredentialProvider Bean for authentication.", e);
-            if (properties.isFailFast()) {
-                throw e;
-            }
+            throw new RuntimeException("Failed to find unique KeyVaultCredentialProvider Bean for authentication.", e);
         } catch (NoSuchBeanDefinitionException e) {
-            LOGGER.info("No TokenCredentialProvider found.");
+            LOGGER.info("No KeyVaultCredentialProvider found.");
         }
-        return new AzureConfigPropertySourceLocator(properties, appProperties, clients, keyVaultCredentialProvider);
+        return new AppConfigurationPropertySourceLocator(properties, appProperties, clients,
+                keyVaultCredentialProvider);
     }
 
     @Bean
-    public ClientStore buildClientStores(AzureCloudConfigProperties properties,
-            AppConfigProviderProperties appProperties, ConnectionPool pool, ApplicationContext context) {
-        AppConfigCredentialProvider tokenCredentialProvider = null;
+    public ClientStore buildClientStores(AppConfigurationProperties properties,
+            AppConfigurationProviderProperties appProperties, ConnectionPool pool, ApplicationContext context) {
+        AppConfigurationCredentialProvider tokenCredentialProvider = null;
         try {
-            tokenCredentialProvider = context.getBean(AppConfigCredentialProvider.class);
+            tokenCredentialProvider = context.getBean(AppConfigurationCredentialProvider.class);
         } catch (NoUniqueBeanDefinitionException e) {
-            LOGGER.error("Failed to find unique TokenCredentialProvider Bean for authentication.", e);
-            if (properties.isFailFast()) {
-                throw e;
-            }
+            throw new RuntimeException(
+                    "Failed to find unique AppConfigurationCredentialProvider Bean for authentication.", e);
         } catch (NoSuchBeanDefinitionException e) {
-            LOGGER.info("No TokenCredentialProvider found.");
+            LOGGER.info("No AppConfigurationCredentialProvider found.");
         }
         return new ClientStore(appProperties, pool, tokenCredentialProvider);
     }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationCredentialProvider.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationCredentialProvider.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.spring.cloud.config;
 
 import com.azure.core.credential.TokenCredential;
 
-public interface AppConfigCredentialProvider {
+public interface AppConfigurationCredentialProvider {
 
     public TokenCredential getAppConfigCredential(String uri);
 

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationProperties.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationProperties.java
@@ -26,9 +26,9 @@ import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 import com.microsoft.azure.spring.cloud.context.core.config.AzureManagedIdentityProperties;
 
 @Validated
-@ConfigurationProperties(prefix = AzureCloudConfigProperties.CONFIG_PREFIX)
-@Import({ AppConfigProviderProperties.class })
-public class AzureCloudConfigProperties {
+@ConfigurationProperties(prefix = AppConfigurationProperties.CONFIG_PREFIX)
+@Import({ AppConfigurationProviderProperties.class })
+public class AppConfigurationProperties {
     public static final String CONFIG_PREFIX = "spring.cloud.azure.appconfiguration";
 
     public static final String LABEL_SEPARATOR = ",";
@@ -52,8 +52,6 @@ public class AzureCloudConfigProperties {
     @NotEmpty
     @Pattern(regexp = "^[a-zA-Z0-9_@]+$")
     private String profileSeparator = "_";
-
-    private boolean failFast = true;
 
     private Duration cacheExpiration = Duration.ofSeconds(30);
 
@@ -106,14 +104,6 @@ public class AzureCloudConfigProperties {
         this.profileSeparator = profileSeparator;
     }
 
-    public boolean isFailFast() {
-        return failFast;
-    }
-
-    public void setFailFast(boolean failFast) {
-        this.failFast = failFast;
-    }
-
     public Duration getCacheExpiration() {
         return cacheExpiration;
     }
@@ -122,7 +112,7 @@ public class AzureCloudConfigProperties {
      * The minimum time between checks. The minimum valid cache time is 1s. The default
      * cache time is 30s.
      * 
-     * @param cache minimum time between refresh checks
+     * @param cacheExpiration minimum time between refresh checks
      */
     public void setCacheExpiration(Duration cacheExpiration) {
         this.cacheExpiration = cacheExpiration;

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySource.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySource.java
@@ -42,8 +42,8 @@ import com.microsoft.azure.spring.cloud.config.stores.ClientStore;
 import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 import com.microsoft.azure.spring.cloud.config.stores.KeyVaultClient;
 
-public class AzureConfigPropertySource extends EnumerablePropertySource<ConfigurationClient> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AzureConfigPropertySource.class);
+public class AppConfigurationPropertySource extends EnumerablePropertySource<ConfigurationClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppConfigurationPropertySource.class);
 
     private final String context;
 
@@ -51,7 +51,7 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
 
     private final String label;
 
-    private AzureCloudConfigProperties azureProperties;
+    private AppConfigurationProperties appConfigurationProperties;
 
     private static ObjectMapper mapper = new ObjectMapper();
 
@@ -61,22 +61,25 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
 
     private KeyVaultCredentialProvider keyVaultCredentialProvider;
 
-    private AppConfigProviderProperties appProperties;
+    private AppConfigurationProviderProperties appProperties;
 
     private ConfigStore configStore;
 
     private Map<String, List<String>> storeContextsMap;
+    
+    private int count = 0;
 
-    AzureConfigPropertySource(String context, ConfigStore configStore, String label,
-            AzureCloudConfigProperties azureProperties, ClientStore clients, AppConfigProviderProperties appProperties,
-            KeyVaultCredentialProvider keyVaultCredentialProvider, Map<String, List<String>> storeContextsMap) {
+    AppConfigurationPropertySource(String context, ConfigStore configStore, String label,
+            AppConfigurationProperties appConfigurationProperties, ClientStore clients,
+            AppConfigurationProviderProperties appProperties, KeyVaultCredentialProvider keyVaultCredentialProvider,
+            Map<String, List<String>> storeContextsMap) {
         // The context alone does not uniquely define a PropertySource, append storeName
         // and label to uniquely define a PropertySource
         super(context + configStore.getEndpoint() + "/" + label);
         this.context = context;
         this.configStore = configStore;
         this.label = label;
-        this.azureProperties = azureProperties;
+        this.appConfigurationProperties = appConfigurationProperties;
         this.appProperties = appProperties;
         this.keyVaultClients = new HashMap<String, KeyVaultClient>();
         this.clients = clients;
@@ -103,7 +106,7 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
      * <p>
      * <b>Note</b>: Doesn't update Feature Management, just stores values in cache. Call
      * {@code initFeatures} to update Feature Management, but make sure its done in the
-     * last {@code AzureConfigPropertySource}
+     * last {@code AppConfigurationPropertySource}
      * </p>
      * 
      * @param featureSet The set of Feature Management Flags from various config stores.
@@ -127,12 +130,8 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
         settingSelector.setKeyFilter(".appconfig*");
         List<ConfigurationSetting> features = clients.listSettings(settingSelector, storeName);
 
-        if (settings == null) {
-            if (!azureProperties.isFailFast()) {
-                return featureSet;
-            } else {
-                throw new IOException("Unable to load properties from App Configuration Store.");
-            }
+        if (settings == null || features == null) {
+            throw new IOException("Unable to load properties from App Configuration Store.");
         }
         for (ConfigurationSetting setting : settings) {
             String key = setting.getKey().trim().substring(context.length()).replace('/', '.');
@@ -163,12 +162,17 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
         List<ConfigurationSetting> featureRevisions = clients.listSettingRevisons(settingSelector, storeName);
 
         if (configurationRevisions != null && !configurationRevisions.isEmpty()) {
-            StateHolder.setState(configStore.getEndpoint() + CONFIGURATION_SUFFIX, configurationRevisions.get(0));
+            StateHolder.setEtagState(configStore.getEndpoint() + CONFIGURATION_SUFFIX, configurationRevisions.get(0));
+        } else {
+            StateHolder.setEtagState(configStore.getEndpoint() + CONFIGURATION_SUFFIX, new ConfigurationSetting());
         }
 
         if (featureRevisions != null && !featureRevisions.isEmpty()) {
-            StateHolder.setState(configStore.getEndpoint() + FEATURE_SUFFIX, featureRevisions.get(0));
+            StateHolder.setEtagState(configStore.getEndpoint() + FEATURE_SUFFIX, featureRevisions.get(0));
+        } else {
+            StateHolder.setEtagState(configStore.getEndpoint() + FEATURE_SUFFIX, new ConfigurationSetting());
         }
+        StateHolder.setLoadState(configStore.getEndpoint(), true);
 
         return featureSet;
     }
@@ -191,28 +195,20 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
                 JsonNode kvReference = mapper.readTree(value);
                 uri = new URI(kvReference.at("/uri").asText());
             } catch (URISyntaxException e) {
-                if (azureProperties.isFailFast()) {
-                    LOGGER.error("Error Processing Key Vault Entry URI.");
-                    ReflectionUtils.rethrowRuntimeException(e);
-                } else {
-                    LOGGER.error("Error Processing Key Vault Entry URI.", e);
-                }
+                LOGGER.error("Error Processing Key Vault Entry URI.");
+                ReflectionUtils.rethrowRuntimeException(e);
             }
 
             // If no entry found don't connect to Key Vault
             if (uri == null) {
-                if (azureProperties.isFailFast()) {
-                    ReflectionUtils.rethrowRuntimeException(
-                            new IOException("Invaid URI when parsing Key Vault Reference."));
-                } else {
-                    return null;
-                }
+                ReflectionUtils.rethrowRuntimeException(
+                        new IOException("Invaid URI when parsing Key Vault Reference."));
             }
 
             // Check if we already have a client for this key vault, if not we will make
             // one
             if (!keyVaultClients.containsKey(uri.getHost())) {
-                KeyVaultClient client = new KeyVaultClient(uri, keyVaultCredentialProvider, azureProperties);
+                KeyVaultClient client = new KeyVaultClient(uri, keyVaultCredentialProvider, appConfigurationProperties);
                 keyVaultClients.put(uri.getHost(), client);
             }
             KeyVaultSecret secret = keyVaultClients.get(uri.getHost()).getSecret(uri, appProperties.getMaxRetryTime());
@@ -221,20 +217,16 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
             }
             secretValue = secret.getValue();
         } catch (RuntimeException | IOException e) {
-            if (!azureProperties.isFailFast()) {
-                LOGGER.error("Error Retreiving Key Vault Entry", e);
-            } else {
-                LOGGER.error("Error Retreiving Key Vault Entry");
-                ReflectionUtils.rethrowRuntimeException(e);
-            }
+            LOGGER.error("Error Retreiving Key Vault Entry");
+            ReflectionUtils.rethrowRuntimeException(e);
         }
         return secretValue;
     }
 
     /**
      * Initializes Feature Management configurations. Only one
-     * {@code AzureConfigPropertySource} can call this, and it needs to be done after the
-     * rest have run initProperties.
+     * {@code AppConfigurationPropertySource} can call this, and it needs to be done after
+     * the rest have run initProperties.
      * @param featureSet Feature Flag info to be set to this property source.
      */
     void initFeatures(FeatureSet featureSet) {
@@ -292,21 +284,13 @@ public class AzureConfigPropertySource extends EnumerablePropertySource<Configur
                 return feature;
 
             } catch (IOException e) {
-                LOGGER.error("Unabled to parse Feature Management values from Azure.", e);
-                if (azureProperties.isFailFast()) {
-                    throw e;
-                }
+                throw new IOException("Unabled to parse Feature Management values from Azure.", e);
             }
 
         } else {
             String message = String.format("Found Feature Flag %s with invalid Content Type of %s", item.getKey(),
                     item.getContentType());
-
-            if (azureProperties.isFailFast()) {
-                throw new IOException(message);
-            }
-            LOGGER.error(message);
+            throw new IOException(message);
         }
-        return feature;
     }
 }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
@@ -97,9 +97,7 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
             }
         }
 
-        if (startup) {
-            startup = false;
-        }
+       startup = false;
 
         return composite;
     }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
@@ -31,8 +31,8 @@ import com.microsoft.azure.spring.cloud.config.feature.management.entity.Feature
 import com.microsoft.azure.spring.cloud.config.stores.ClientStore;
 import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 
-public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AzureConfigPropertySourceLocator.class);
+public class AppConfigurationPropertySourceLocator implements PropertySourceLocator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppConfigurationPropertySourceLocator.class);
 
     private static final String SPRING_APP_NAME_PROP = "spring.application.name";
 
@@ -40,7 +40,7 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
 
     private static final String PATH_SPLITTER = "/";
 
-    private final AzureCloudConfigProperties properties;
+    private final AppConfigurationProperties properties;
 
     private final String profileSeparator;
 
@@ -48,14 +48,16 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
 
     private final Map<String, List<String>> storeContextsMap = new ConcurrentHashMap<>();
 
-    private AppConfigProviderProperties appProperties;
+    private AppConfigurationProviderProperties appProperties;
 
     private ClientStore clients;
 
     private KeyVaultCredentialProvider keyVaultCredentialProvider;
 
-    public AzureConfigPropertySourceLocator(AzureCloudConfigProperties properties,
-            AppConfigProviderProperties appProperties, ClientStore clients,
+    private static Boolean startup = true;
+
+    public AppConfigurationPropertySourceLocator(AppConfigurationProperties properties,
+            AppConfigurationProviderProperties appProperties, ClientStore clients,
             KeyVaultCredentialProvider keyVaultCredentialProvider) {
         this.properties = properties;
         this.appProperties = appProperties;
@@ -87,8 +89,16 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
         // Feature Management needs to be set in the last config store.
         while (configStoreIterator.hasNext()) {
             ConfigStore configStore = configStoreIterator.next();
-            addPropertySource(composite, configStore, applicationName, profiles, storeContextsMap,
-                    !configStoreIterator.hasNext());
+            if (startup || (!startup && StateHolder.getLoadState(configStore.getEndpoint()))) {
+                addPropertySource(composite, configStore, applicationName, profiles, storeContextsMap,
+                        !configStoreIterator.hasNext());
+            } else {
+                LOGGER.warn("Not loading configurations from {} as it failed on startup.", configStore.getEndpoint());
+            }
+        }
+
+        if (startup) {
+            startup = false;
         }
 
         return composite;
@@ -121,7 +131,7 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
         contexts.addAll(generateContexts(this.properties.getDefaultContext(), profiles, store));
         contexts.addAll(generateContexts(applicationName, profiles, store));
 
-        // There is only one Feature Set for all AzureConfigPropertySources
+        // There is only one Feature Set for all AppConfigurationPropertySources
         FeatureSet featureSet = new FeatureSet();
 
         // Reverse in order to add Profile specific properties earlier, and last profile
@@ -129,17 +139,20 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
         Collections.reverse(contexts);
         for (String sourceContext : contexts) {
             try {
-                List<AzureConfigPropertySource> sourceList = create(sourceContext, store, storeContextsMap,
+                List<AppConfigurationPropertySource> sourceList = create(sourceContext, store, storeContextsMap,
                         initFeatures, featureSet);
                 sourceList.forEach(composite::addPropertySource);
                 LOGGER.debug("PropertySource context [{}] is added.", sourceContext);
             } catch (Exception e) {
-                if (properties.isFailFast()) {
-                    LOGGER.error("Fail fast is set and there was an error reading configuration from Azure Config " +
-                            "Service for " + sourceContext);
+                if (store.isFailFast() || !startup) {
+                    LOGGER.error(
+                            "Fail fast is set and there was an error reading configuration from Azure App "
+                                    + "Configuration Service for " + sourceContext);
                     ReflectionUtils.rethrowRuntimeException(e);
                 } else {
-                    LOGGER.warn("Unable to load configuration from Azure Config Service for " + sourceContext, e);
+                    LOGGER.warn("Unable to load configuration from Azure AppConfiguration Service for " + sourceContext,
+                            e);
+                    StateHolder.setLoadState(store.getEndpoint(), false);
                 }
             }
         }
@@ -174,23 +187,23 @@ public class AzureConfigPropertySourceLocator implements PropertySourceLocator {
     }
 
     /**
-     * Creates a new set of AzureConfigProertySources, 1 per Label.
+     * Creates a new set of AppConfigurationProertySources, 1 per Label.
      * 
      * @param context Context of the application, part of uniquely define a PropertySource
      * @param store Config Store the PropertySource is being generated from
      * @param storeContextsMap the Map storing the storeName -> List of contexts map
      * @param initFeatures determines if Feature Management is set in the PropertySource.
      * When generating more than one it needs to be in the last one.
-     * @return a list of AzureConfigPropertySources
+     * @return a list of AppConfigurationPropertySources
      */
-    private List<AzureConfigPropertySource> create(String context, ConfigStore store,
+    private List<AppConfigurationPropertySource> create(String context, ConfigStore store,
             Map<String, List<String>> storeContextsMap, boolean initFeatures, FeatureSet featureSet) throws Exception {
-        List<AzureConfigPropertySource> sourceList = new ArrayList<>();
+        List<AppConfigurationPropertySource> sourceList = new ArrayList<>();
 
         try {
             for (String label : store.getLabels()) {
                 putStoreContext(store.getEndpoint(), context, storeContextsMap);
-                AzureConfigPropertySource propertySource = new AzureConfigPropertySource(context, store,
+                AppConfigurationPropertySource propertySource = new AppConfigurationPropertySource(context, store,
                         label, properties, clients, appProperties, keyVaultCredentialProvider, storeContextsMap);
 
                 propertySource.initProperties(featureSet);

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationProviderProperties.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationProviderProperties.java
@@ -19,8 +19,8 @@ import org.springframework.validation.annotation.Validated;
 @Configuration
 @Validated
 @PropertySource("classpath:appConfiguration.yaml")
-@ConfigurationProperties(prefix = AppConfigProviderProperties.CONFIG_PREFIX)
-public class AppConfigProviderProperties {
+@ConfigurationProperties(prefix = AppConfigurationProviderProperties.CONFIG_PREFIX)
+public class AppConfigurationProviderProperties {
     public static final String CONFIG_PREFIX = "spring.cloud.appconfiguration";
 
     @NotEmpty

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
@@ -30,8 +30,8 @@ import com.azure.data.appconfiguration.models.SettingSelector;
 import com.microsoft.azure.spring.cloud.config.stores.ClientStore;
 import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 
-public class AzureCloudConfigRefresh implements ApplicationEventPublisherAware {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AzureCloudConfigRefresh.class);
+public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppConfigurationRefresh.class);
 
     private final AtomicBoolean running = new AtomicBoolean(false);
 
@@ -49,7 +49,7 @@ public class AzureCloudConfigRefresh implements ApplicationEventPublisherAware {
 
     private String eventDataInfo;
 
-    public AzureCloudConfigRefresh(AzureCloudConfigProperties properties, Map<String, List<String>> storeContextsMap,
+    public AppConfigurationRefresh(AppConfigurationProperties properties, Map<String, List<String>> storeContextsMap,
             ClientStore clientStore) {
         this.configStores = properties.getStores();
         this.storeContextsMap = storeContextsMap;
@@ -96,12 +96,14 @@ public class AzureCloudConfigRefresh implements ApplicationEventPublisherAware {
                 Date date = new Date();
                 if (notCachedTime == null || date.after(notCachedTime)) {
                     for (ConfigStore configStore : configStores) {
-                        String watchedKeyNames = clientStore.watchedKeyNames(configStore, storeContextsMap);
-                        willRefresh = refresh(configStore, CONFIGURATION_SUFFIX, watchedKeyNames) ? true
-                                : willRefresh;
-                        // Refresh Feature Flags
-                        willRefresh = refresh(configStore, FEATURE_SUFFIX, FEATURE_STORE_WATCH_KEY) ? true
-                                : willRefresh;
+                        if (StateHolder.getLoadState(configStore.getEndpoint())) {
+                            String watchedKeyNames = clientStore.watchedKeyNames(configStore, storeContextsMap);
+                            willRefresh = refresh(configStore, CONFIGURATION_SUFFIX, watchedKeyNames) ? true
+                                    : willRefresh;
+                            // Refresh Feature Flags
+                            willRefresh = refresh(configStore, FEATURE_SUFFIX, FEATURE_STORE_WATCH_KEY) ? true
+                                    : willRefresh;
+                        }
                     }
                     // Resetting last Checked date to now.
                     lastCheckedTime = new Date();
@@ -141,8 +143,8 @@ public class AzureCloudConfigRefresh implements ApplicationEventPublisherAware {
         if (items != null && !items.isEmpty()) {
             etag = items.get(0).getETag();
         }
-        
-        if (StateHolder.getState(storeNameWithSuffix) == null) {
+
+        if (StateHolder.getEtagState(storeNameWithSuffix) == null) {
             // Should never be the case as Property Source should set the state, but if
             // etag != null return true.
             if (etag != null) {
@@ -150,8 +152,8 @@ public class AzureCloudConfigRefresh implements ApplicationEventPublisherAware {
             }
             return false;
         }
-        
-        if (!etag.equals(StateHolder.getState(storeNameWithSuffix).getETag())) {
+
+        if (!etag.equals(StateHolder.getEtagState(storeNameWithSuffix).getETag())) {
             LOGGER.trace("Some keys in store [{}] matching [{}] is updated, will send refresh event.",
                     store.getEndpoint(), watchedKeyNames);
             if (this.eventDataInfo.isEmpty()) {

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigListener.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/ConfigListener.java
@@ -15,16 +15,16 @@ import org.springframework.web.context.support.ServletRequestHandledEvent;
 public class ConfigListener implements ApplicationListener<ServletRequestHandledEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigListener.class);
 
-    private AzureCloudConfigRefresh azureCloudConfigRefresh;
+    private AppConfigurationRefresh appConfigurationRefresh;
 
-    public ConfigListener(AzureCloudConfigRefresh azureCloudConfigRefresh) {
-        this.azureCloudConfigRefresh = azureCloudConfigRefresh;
+    public ConfigListener(AppConfigurationRefresh appConfigurationRefresh) {
+        this.appConfigurationRefresh = appConfigurationRefresh;
     }
 
     @Override
     public void onApplicationEvent(ServletRequestHandledEvent event) {
         try {
-            azureCloudConfigRefresh.refreshConfigurations();
+            appConfigurationRefresh.refreshConfigurations();
         } catch (Exception e) {
             LOGGER.error("Refresh failed with unexpected exception.", e);
         }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/StateHolder.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/StateHolder.java
@@ -9,21 +9,43 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
 
-public final class StateHolder {
+final class StateHolder {
 
     private StateHolder() {
         throw new IllegalStateException("Should not be callable.");
     }
 
-    private static ConcurrentHashMap<String, ConfigurationSetting> state = 
+    private static ConcurrentHashMap<String, ConfigurationSetting> etagState = 
             new ConcurrentHashMap<String, ConfigurationSetting>();
 
-    public static ConfigurationSetting getState(String name) {
-        return state.get(name);
+    private static ConcurrentHashMap<String, Boolean> loadState = new ConcurrentHashMap<String, Boolean>();
+
+    /**
+     * @return the etagState
+     */
+    public static ConfigurationSetting getEtagState(String name) {
+        return etagState.get(name);
     }
 
-    public static void setState(String name, ConfigurationSetting setting) {
-        state.put(name, setting);
+    /**
+     * @param etagState the etagState to set
+     */
+    static void setEtagState(String name, ConfigurationSetting config) {
+        etagState.put(name, config);
+    }
+
+    /**
+     * @return the loadState
+     */
+    public static Boolean getLoadState(String name) {
+        return loadState.get(name);
+    }
+
+    /**
+     * @param loadState the loadState to set
+     */
+    public static void setLoadState(String name, Boolean loaded) {
+        loadState.put(name, loaded);
     }
 
 }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/StateHolder.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/StateHolder.java
@@ -38,7 +38,8 @@ final class StateHolder {
      * @return the loadState
      */
     public static Boolean getLoadState(String name) {
-        return loadState.get(name);
+        Boolean loadstate = loadState.get(name);
+        return loadstate == null ? false : loadstate;
     }
 
     /**

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
@@ -103,7 +103,6 @@ public class ClientStore {
      */
     public final List<ConfigurationSetting> listSettingRevisons(SettingSelector settingSelector, String storeName) {
         ConfigurationAsyncClient client = buildClient(storeName);
-
         return client.listRevisions(settingSelector).collectList().block();
     }
 

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
@@ -23,22 +23,22 @@ import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
 import com.azure.data.appconfiguration.models.SettingSelector;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
-import com.microsoft.azure.spring.cloud.config.AppConfigCredentialProvider;
-import com.microsoft.azure.spring.cloud.config.AppConfigProviderProperties;
+import com.microsoft.azure.spring.cloud.config.AppConfigurationCredentialProvider;
+import com.microsoft.azure.spring.cloud.config.AppConfigurationProviderProperties;
 import com.microsoft.azure.spring.cloud.config.pipline.policies.BaseAppConfigurationPolicy;
 import com.microsoft.azure.spring.cloud.config.resource.Connection;
 import com.microsoft.azure.spring.cloud.config.resource.ConnectionPool;
 
 public class ClientStore {
 
-    private AppConfigProviderProperties appProperties;
+    private AppConfigurationProviderProperties appProperties;
 
     private ConnectionPool pool;
 
-    private AppConfigCredentialProvider tokenCredentialProvider;
+    private AppConfigurationCredentialProvider tokenCredentialProvider;
 
-    public ClientStore(AppConfigProviderProperties appProperties,
-            ConnectionPool pool, AppConfigCredentialProvider tokenCredentialProvider) {
+    public ClientStore(AppConfigurationProviderProperties appProperties,
+            ConnectionPool pool, AppConfigurationCredentialProvider tokenCredentialProvider) {
         this.appProperties = appProperties;
         this.pool = pool;
         this.tokenCredentialProvider = tokenCredentialProvider;

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ConfigStore.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ConfigStore.java
@@ -5,7 +5,7 @@
  */
 package com.microsoft.azure.spring.cloud.config.stores;
 
-import static com.microsoft.azure.spring.cloud.config.AzureCloudConfigProperties.LABEL_SEPARATOR;
+import static com.microsoft.azure.spring.cloud.config.AppConfigurationProperties.LABEL_SEPARATOR;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,6 +41,8 @@ public class ConfigStore {
     // The keys to be watched, won't take effect if watch not enabled
     @NotEmpty
     private String watchedKey = "*";
+    
+    private boolean failFast = true;
 
     public ConfigStore() {
     }
@@ -83,6 +85,14 @@ public class ConfigStore {
 
     public void setWatchedKey(String watchedKey) {
         this.watchedKey = watchedKey;
+    }
+    
+    public boolean isFailFast() {
+        return failFast;
+    }
+
+    public void setFailFast(boolean failFast) {
+        this.failFast = failFast;
     }
 
     @PostConstruct

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/KeyVaultClient.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/KeyVaultClient.java
@@ -15,7 +15,7 @@ import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretAsyncClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import com.microsoft.azure.spring.cloud.config.AzureCloudConfigProperties;
+import com.microsoft.azure.spring.cloud.config.AppConfigurationProperties;
 import com.microsoft.azure.spring.cloud.config.KeyVaultCredentialProvider;
 import com.microsoft.azure.spring.cloud.context.core.config.AzureManagedIdentityProperties;
 
@@ -32,7 +32,7 @@ public class KeyVaultClient {
      * @param properties Azure Configuration Managed Identity credentials
      */
     public KeyVaultClient(URI uri, KeyVaultCredentialProvider tokenCredentialProvider,
-            AzureCloudConfigProperties properties) {
+            AppConfigurationProperties properties) {
         SecretClientBuilder builder = new SecretClientBuilder();
         TokenCredential tokenCredential = null;
         if (tokenCredentialProvider != null) {

--- a/spring-cloud-azure-appconfiguration-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-azure-appconfiguration-config/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.microsoft.azure.spring.cloud.config.AzureCloudConfigAutoConfiguration
+com.microsoft.azure.spring.cloud.config.AppConfigurationAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
-com.microsoft.azure.spring.cloud.config.AzureConfigBootstrapConfiguration
+com.microsoft.azure.spring.cloud.config.AppConfigurationBootstrapConfiguration
 

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationAutoConfigurationTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationAutoConfigurationTest.java
@@ -17,12 +17,12 @@ import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-public class AzureCloudConfigAutoConfigurationTest {
+public class AppConfigurationAutoConfigurationTest {
     private static final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withPropertyValues(propPair(CONN_STRING_PROP, TEST_CONN_STRING),
                     propPair(STORE_ENDPOINT_PROP, TEST_STORE_NAME))
-            .withConfiguration(AutoConfigurations.of(AzureConfigBootstrapConfiguration.class,
-                    AzureCloudConfigAutoConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(AppConfigurationBootstrapConfiguration.class,
+                    AppConfigurationAutoConfiguration.class));
 
     @Test
     public void watchEnabledNotConfiguredShouldNotCreateWatch() {

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationBootstrapConfigurationTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationBootstrapConfigurationTest.java
@@ -42,13 +42,13 @@ import com.microsoft.rest.RestClient;
 import com.microsoft.rest.RestClient.Builder;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(AzureConfigBootstrapConfiguration.class)
+@PrepareForTest(AppConfigurationBootstrapConfiguration.class)
 @PowerMockIgnore({ "javax.net.ssl.*", "javax.crypto.*" })
-public class AzureConfigBootstrapConfigurationTest {
+public class AppConfigurationBootstrapConfigurationTest {
     private static final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withPropertyValues(propPair(CONN_STRING_PROP, TEST_CONN_STRING),
                     propPair(STORE_ENDPOINT_PROP, TEST_STORE_NAME))
-            .withConfiguration(AutoConfigurations.of(AzureConfigBootstrapConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(AppConfigurationBootstrapConfiguration.class));
 
     @Mock
     private MSICredentials msiCredentials;
@@ -97,7 +97,7 @@ public class AzureConfigBootstrapConfigurationTest {
     public void propertySourceLocatorBeanCreated() throws Exception {
         whenNew(ClientStore.class).withAnyArguments().thenReturn(clientStoreMock);
         contextRunner.withPropertyValues(propPair(FAIL_FAST_PROP, "false"))
-                .run(context -> assertThat(context).hasSingleBean(AzureConfigPropertySourceLocator.class));
+                .run(context -> assertThat(context).hasSingleBean(AppConfigurationPropertySourceLocator.class));
     }
 
     @Test

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertiesTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertiesTest.java
@@ -54,12 +54,12 @@ import org.springframework.context.annotation.Configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(AzureConfigBootstrapConfiguration.class)
+@PrepareForTest(AppConfigurationBootstrapConfiguration.class)
 @PowerMockIgnore({ "javax.net.ssl.*", "javax.crypto.*", "org.mockito.*" })
-public class AzureCloudConfigPropertiesTest {
+public class AppConfigurationPropertiesTest {
     @InjectMocks
     private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(AzureConfigBootstrapConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(AppConfigurationBootstrapConfiguration.class));
 
     private static final String NO_ENDPOINT_CONN_STRING = "Id=fake-conn-id;Secret=ZmFrZS1jb25uLXNlY3JldA==";
 
@@ -115,7 +115,7 @@ public class AzureCloudConfigPropertiesTest {
     public void validInputShouldCreatePropertiesBean() {
         this.contextRunner.withPropertyValues(propPair(CONN_STRING_PROP, TEST_CONN_STRING))
                 .withPropertyValues(propPair(FAIL_FAST_PROP, "false")).run(context -> {
-                    assertThat(context).hasSingleBean(AzureCloudConfigProperties.class);
+                    assertThat(context).hasSingleBean(AppConfigurationProperties.class);
                 });
     }
 
@@ -192,7 +192,7 @@ public class AzureCloudConfigPropertiesTest {
         this.contextRunner.withPropertyValues(propPair(CONN_STRING_PROP, TEST_CONN_STRING),
                 propPair(STORE_ENDPOINT_PROP, "")).withPropertyValues(propPair(FAIL_FAST_PROP, "false"))
                 .run(context -> {
-                    AzureCloudConfigProperties properties = context.getBean(AzureCloudConfigProperties.class);
+                    AppConfigurationProperties properties = context.getBean(AppConfigurationProperties.class);
                     assertThat(properties.getStores()).isNotNull();
                     assertThat(properties.getStores().size()).isEqualTo(1);
                     assertThat(properties.getStores().get(0).getEndpoint()).isEqualTo("https://fake.test.config.io");
@@ -221,7 +221,7 @@ public class AzureCloudConfigPropertiesTest {
         this.contextRunner.withPropertyValues(propPair(CONN_STRING_PROP, TEST_CONN_STRING))
                 .withPropertyValues(propPair(CACHE_EXPIRATION_PROP, "1s"))
                 .run(context -> {
-                    assertThat(context).hasSingleBean(AzureCloudConfigProperties.class);
+                    assertThat(context).hasSingleBean(AppConfigurationProperties.class);
                 });
     }
 
@@ -233,7 +233,7 @@ public class AzureCloudConfigPropertiesTest {
 }
 
 @Configuration
-@EnableConfigurationProperties(AzureCloudConfigProperties.class)
+@EnableConfigurationProperties(AppConfigurationProperties.class)
 class PropertiesTestConfiguration {
     // Do nothing
 }

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceKeyVaultTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceKeyVaultTest.java
@@ -61,11 +61,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ AzureConfigPropertySource.class })
-public class AzureConfigPropertySourceKeyVaultTest {
+@PrepareForTest({ AppConfigurationPropertySource.class })
+public class AppConfigurationPropertySourceKeyVaultTest {
     private static final String EMPTY_CONTENT_TYPE = "";
 
-    private static final AzureCloudConfigProperties TEST_PROPS = new AzureCloudConfigProperties();
+    private static final AppConfigurationProperties TEST_PROPS = new AppConfigurationProperties();
 
     public static final List<ConfigurationSetting> TEST_ITEMS = new ArrayList<>();
 
@@ -85,11 +85,11 @@ public class AzureConfigPropertySourceKeyVaultTest {
 
     public List<ConfigurationSetting> testItems = new ArrayList<>();
 
-    private AzureConfigPropertySource propertySource;
+    private AppConfigurationPropertySource propertySource;
 
-    private AzureCloudConfigProperties azureProperties;
+    private AppConfigurationProperties appConfigurationProperties;
 
-    private AppConfigProviderProperties appProperties;
+    private AppConfigurationProviderProperties appProperties;
 
     @Mock
     private ClientStore clientStoreMock;
@@ -114,7 +114,7 @@ public class AzureConfigPropertySourceKeyVaultTest {
 
     @Rule
     public ExpectedException expected = ExpectedException.none();
-    
+
     private KeyVaultCredentialProvider tokenCredentialProvider = null;
 
     @BeforeClass
@@ -127,9 +127,8 @@ public class AzureConfigPropertySourceKeyVaultTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        azureProperties = new AzureCloudConfigProperties();
-        azureProperties.setFailFast(true);
-        appProperties = new AppConfigProviderProperties();
+        appConfigurationProperties = new AppConfigurationProperties();
+        appProperties = new AppConfigurationProviderProperties();
         appProperties.setMaxRetryTime(0);
         ConfigStore testStore = new ConfigStore();
         testStore.setEndpoint(TEST_STORE_NAME);
@@ -137,8 +136,8 @@ public class AzureConfigPropertySourceKeyVaultTest {
         ArrayList<String> contexts = new ArrayList<String>();
         contexts.add("/application/*");
         storeContextsMap.put(TEST_STORE_NAME, contexts);
-        propertySource = new AzureConfigPropertySource(TEST_CONTEXT, testStore, "\0",
-                azureProperties, clientStoreMock, appProperties, tokenCredentialProvider, storeContextsMap);
+        propertySource = new AppConfigurationPropertySource(TEST_CONTEXT, testStore, "\0",
+                appConfigurationProperties, clientStoreMock, appProperties, tokenCredentialProvider, storeContextsMap);
 
         testItems = new ArrayList<ConfigurationSetting>();
         testItems.add(item1);

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
@@ -148,6 +148,7 @@ public class AppConfigurationPropertySourceLocatorTest {
         Field field = AppConfigurationPropertySourceLocator.class.getDeclaredField("startup");
         field.setAccessible(true);
         field.set(null, true);
+        StateHolder.setLoadState(TEST_STORE_NAME,  false);
     }
 
     @Test
@@ -259,6 +260,25 @@ public class AppConfigurationPropertySourceLocatorTest {
         when(clientStoreMock.listSettings(Mockito.any(), Mockito.anyString())).thenThrow(new RuntimeException());
         locator.locate(environment);
         verify(configStoreMock, times(1)).isFailFast();
+    }
+
+    @Test
+    public void refreshThrowException() throws IOException, NoSuchFieldException, SecurityException,
+            IllegalArgumentException, IllegalAccessException {
+        Field field = AppConfigurationPropertySourceLocator.class.getDeclaredField("startup");
+        field.setAccessible(true);
+        field.set(null, false);
+        StateHolder.setLoadState(TEST_STORE_NAME,  true);
+
+        expected.expect(NullPointerException.class);
+        
+        when(environment.getActiveProfiles()).thenReturn(new String[] {});
+        when(environment.getProperty("spring.application.name")).thenReturn(null);
+
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties,
+                clientStoreMock, tokenCredentialProvider);
+
+        locator.locate(environment);
     }
 
     @Test

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
@@ -15,14 +15,18 @@ import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_N
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_NAME_2;
 import static com.microsoft.azure.spring.cloud.config.TestUtils.createItem;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -40,10 +44,11 @@ import com.azure.core.http.rest.PagedResponse;
 import com.azure.data.appconfiguration.ConfigurationAsyncClient;
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
 import com.microsoft.azure.spring.cloud.config.stores.ClientStore;
+import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 
 import reactor.core.publisher.Flux;
 
-public class AzureConfigPropertySourceLocatorTest {
+public class AppConfigurationPropertySourceLocatorTest {
     private static final String APPLICATION_NAME = "foo";
 
     private static final String PROFILE_NAME_1 = "dev";
@@ -64,7 +69,7 @@ public class AzureConfigPropertySourceLocatorTest {
     private ConfigurableEnvironment environment;
 
     @Mock
-    private ClientStore configStoreMock;
+    private ClientStore clientStoreMock;
 
     @Mock
     private ConfigurationAsyncClient configClientMock;
@@ -84,11 +89,21 @@ public class AzureConfigPropertySourceLocatorTest {
     @Mock
     private PagedResponse<ConfigurationSetting> pagedMock;
 
-    private AzureCloudConfigProperties properties;
+    @Mock
+    private List<ConfigStore> configStoresMock;
 
-    private AzureConfigPropertySourceLocator locator;
+    @Mock
+    private ConfigStore configStoreMock;
 
-    private AppConfigProviderProperties appProperties;
+    @Mock
+    private Iterator<ConfigStore> configStoreIterator;
+
+    @Mock
+    private AppConfigurationProperties properties;
+
+    private AppConfigurationPropertySourceLocator locator;
+
+    private AppConfigurationProviderProperties appProperties;
 
     private KeyVaultCredentialProvider tokenCredentialProvider = null;
 
@@ -102,9 +117,17 @@ public class AzureConfigPropertySourceLocatorTest {
         MockitoAnnotations.initMocks(this);
         when(environment.getActiveProfiles()).thenReturn(new String[] { PROFILE_NAME_1, PROFILE_NAME_2 });
 
-        properties = new AzureCloudConfigProperties();
-        TestUtils.addStore(properties, TEST_STORE_NAME, TEST_CONN_STRING);
-        properties.setName(APPLICATION_NAME);
+        when(properties.getName()).thenReturn(APPLICATION_NAME);
+        when(properties.getProfileSeparator()).thenReturn("_");
+        when(properties.getStores()).thenReturn(configStoresMock);
+        when(properties.isEnabled()).thenReturn(true);
+        when(configStoresMock.iterator()).thenReturn(configStoreIterator);
+        when(configStoreIterator.hasNext()).thenReturn(true).thenReturn(false);
+        when(configStoreIterator.next()).thenReturn(configStoreMock);
+
+        when(configStoreMock.getConnectionString()).thenReturn(TEST_CONN_STRING);
+        when(configStoreMock.getEndpoint()).thenReturn(TEST_STORE_NAME);
+        when(configStoreMock.getPrefix()).thenReturn(null);
 
         when(configClientMock.listConfigurationSettings(Mockito.any())).thenReturn(settingsMock);
         when(settingsMock.byPage()).thenReturn(pageMock);
@@ -113,15 +136,28 @@ public class AzureConfigPropertySourceLocatorTest {
         when(iteratorMock.next()).thenReturn(pagedMock);
         when(pagedMock.getItems()).thenReturn(new ArrayList<ConfigurationSetting>());
 
-        appProperties = new AppConfigProviderProperties();
+        appProperties = new AppConfigurationProviderProperties();
         appProperties.setVersion("1.0");
         appProperties.setMaxRetries(12);
         appProperties.setMaxRetryTime(0);
     }
 
+    @After
+    public void cleanup()
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        Field field = AppConfigurationPropertySourceLocator.class.getDeclaredField("startup");
+        field.setAccessible(true);
+        field.set(null, true);
+    }
+
     @Test
     public void compositeSourceIsCreated() {
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties, configStoreMock,
+        String[] labels = new String[1];
+        labels[0] = "\0";
+        when(configStoreMock.getLabels()).thenReturn(labels);
+        when(properties.getDefaultContext()).thenReturn("application");
+
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties, clientStoreMock,
                 tokenCredentialProvider);
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);
@@ -139,8 +175,12 @@ public class AzureConfigPropertySourceLocatorTest {
 
     @Test
     public void compositeSourceIsCreatedForPrefixedConfig() {
-        properties.getStores().get(0).setPrefix(PREFIX);
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties, configStoreMock,
+        String[] labels = new String[1];
+        labels[0] = "\0";
+        when(configStoreMock.getLabels()).thenReturn(labels);
+        when(configStoreMock.getPrefix()).thenReturn(PREFIX);
+        when(properties.getDefaultContext()).thenReturn("application");
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties, clientStoreMock,
                 tokenCredentialProvider);
 
         PropertySource<?> source = locator.locate(environment);
@@ -161,11 +201,16 @@ public class AzureConfigPropertySourceLocatorTest {
 
     @Test
     public void nullApplicationNameCreateDefaultContextOnly() {
+        String[] labels = new String[1];
+        labels[0] = "\0";
+        when(configStoreMock.getLabels()).thenReturn(labels);
         when(environment.getActiveProfiles()).thenReturn(new String[] {});
         when(environment.getProperty("spring.application.name")).thenReturn(null);
-        properties.setName(null);
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties,
-                configStoreMock, tokenCredentialProvider);
+        when(properties.getDefaultContext()).thenReturn("application");
+        when(properties.getName()).thenReturn(null);
+
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties,
+                clientStoreMock, tokenCredentialProvider);
 
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);
@@ -180,11 +225,15 @@ public class AzureConfigPropertySourceLocatorTest {
 
     @Test
     public void emptyApplicationNameCreateDefaultContextOnly() {
+        String[] labels = new String[1];
+        labels[0] = "\0";
+        when(configStoreMock.getLabels()).thenReturn(labels);
         when(environment.getActiveProfiles()).thenReturn(new String[] {});
         when(environment.getProperty("spring.application.name")).thenReturn("");
-        properties.setName("");
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties,
-                configStoreMock, tokenCredentialProvider);
+        when(properties.getName()).thenReturn("");
+        when(properties.getDefaultContext()).thenReturn("application");
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties,
+                clientStoreMock, tokenCredentialProvider);
 
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);
@@ -199,36 +248,48 @@ public class AzureConfigPropertySourceLocatorTest {
 
     @Test
     public void defaultFailFastThrowException() throws IOException {
-        expected.expect(RuntimeException.class);
+        expected.expect(NullPointerException.class);
 
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties,
-                configStoreMock, tokenCredentialProvider);
+        when(configStoreMock.isFailFast()).thenReturn(true);
+        when(properties.getDefaultContext()).thenReturn("application");
 
-        when(configStoreMock.listSettings(Mockito.any(), Mockito.anyString())).thenThrow(new RuntimeException());
-        assertThat(properties.isFailFast()).isTrue();
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties,
+                clientStoreMock, tokenCredentialProvider);
+
+        when(clientStoreMock.listSettings(Mockito.any(), Mockito.anyString())).thenThrow(new RuntimeException());
         locator.locate(environment);
+        verify(configStoreMock, times(1)).isFailFast();
     }
 
     @Test
-    public void notFailFastShouldPass() {
-        properties.setFailFast(false);
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties,
-                configStoreMock, tokenCredentialProvider);
+    public void notFailFastShouldPass() throws IOException {
+        when(configStoreMock.isFailFast()).thenReturn(false);
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties,
+                clientStoreMock, tokenCredentialProvider);
+
+        when(configStoreMock.isFailFast()).thenReturn(false);
+        when(clientStoreMock.listSettings(Mockito.any(), Mockito.anyString())).thenThrow(new RuntimeException());
+        when(configStoreMock.getEndpoint()).thenReturn(TEST_STORE_NAME);
 
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);
+        verify(configStoreMock, times(3)).isFailFast();
     }
 
     @Test
     public void multiplePropertySourcesExistForMultiStores() {
+        String[] labels = new String[1];
+        labels[0] = "\0";
+        when(configStoreMock.getLabels()).thenReturn(labels);
         when(environment.getActiveProfiles()).thenReturn(new String[] {});
+        when(configStoreMock.getEndpoint()).thenReturn(TEST_STORE_NAME);
 
-        properties = new AzureCloudConfigProperties();
+        properties = new AppConfigurationProperties();
         TestUtils.addStore(properties, TEST_STORE_NAME_1, TEST_CONN_STRING);
         TestUtils.addStore(properties, TEST_STORE_NAME_2, TEST_CONN_STRING_2);
 
-        locator = new AzureConfigPropertySourceLocator(properties, appProperties,
-                configStoreMock, tokenCredentialProvider);
+        locator = new AppConfigurationPropertySourceLocator(properties, appProperties,
+                clientStoreMock, tokenCredentialProvider);
 
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceTest.java
@@ -61,10 +61,10 @@ import com.microsoft.azure.spring.cloud.config.stores.ConfigStore;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class AzureConfigPropertySourceTest {
+public class AppConfigurationPropertySourceTest {
     private static final String EMPTY_CONTENT_TYPE = "";
 
-    private static final AzureCloudConfigProperties TEST_PROPS = new AzureCloudConfigProperties();
+    private static final AppConfigurationProperties TEST_PROPS = new AppConfigurationProperties();
 
     public static final List<ConfigurationSetting> TEST_ITEMS = new ArrayList<>();
 
@@ -97,11 +97,11 @@ public class AzureConfigPropertySourceTest {
 
     private static final String FEATURE_MANAGEMENT_KEY = "feature-management.featureManagement";
 
-    private AzureConfigPropertySource propertySource;
+    private AppConfigurationPropertySource propertySource;
 
     private static ObjectMapper mapper = new ObjectMapper();
 
-    private AzureCloudConfigProperties azureProperties;
+    private AppConfigurationProperties appConfigurationProperties;
 
     @Mock
     private ClientStore clientStoreMock;
@@ -130,7 +130,7 @@ public class AzureConfigPropertySourceTest {
     @Rule
     public ExpectedException expected = ExpectedException.none();
 
-    private AppConfigProviderProperties appProperties;
+    private AppConfigurationProviderProperties appProperties;
 
     private KeyVaultCredentialProvider tokenCredentialProvider = null;
 
@@ -146,17 +146,16 @@ public class AzureConfigPropertySourceTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        azureProperties = new AzureCloudConfigProperties();
-        azureProperties.setFailFast(true);
-        appProperties = new AppConfigProviderProperties();
+        appConfigurationProperties = new AppConfigurationProperties();
+        appProperties = new AppConfigurationProviderProperties();
         ConfigStore configStore = new ConfigStore();
         configStore.setEndpoint(TEST_STORE_NAME);
         Map<String, List<String>> storeContextsMap = new HashMap<String, List<String>>();
         ArrayList<String> contexts = new ArrayList<String>();
         contexts.add("/application/*");
         storeContextsMap.put(TEST_STORE_NAME, contexts);
-        propertySource = new AzureConfigPropertySource(TEST_CONTEXT, configStore, "\0",
-                azureProperties, clientStoreMock, appProperties, tokenCredentialProvider, storeContextsMap);
+        propertySource = new AppConfigurationPropertySource(TEST_CONTEXT, configStore, "\0",
+                appConfigurationProperties, clientStoreMock, appProperties, tokenCredentialProvider, storeContextsMap);
 
         testItems = new ArrayList<ConfigurationSetting>();
         testItems.add(item1);

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestUtils.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/TestUtils.java
@@ -31,16 +31,16 @@ public class TestUtils {
         return item;
     }
 
-    static void addStore(AzureCloudConfigProperties properties, String storeName, String connectionString) {
-        addStore(properties, storeName, connectionString, null);
+    static void addStore(AppConfigurationProperties properties, String storeEndpoint, String connectionString) {
+        addStore(properties, storeEndpoint, connectionString, null);
     }
 
-    static void addStore(AzureCloudConfigProperties properties, String storeName, String connectionString,
+    static void addStore(AppConfigurationProperties properties, String storeEndpoint, String connectionString,
                          String label) {
         List<ConfigStore> stores = properties.getStores();
         ConfigStore store = new ConfigStore();
         store.setConnectionString(connectionString);
-        store.setEndpoint(storeName);
+        store.setEndpoint(storeEndpoint);
         store.setLabel(label);
         stores.add(store);
         properties.setStores(stores);

--- a/spring-cloud-azure-starters/spring-cloud-starter-azure-appconfiguration-config/README.md
+++ b/spring-cloud-azure-starters/spring-cloud-starter-azure-appconfiguration-config/README.md
@@ -36,7 +36,6 @@ spring.cloud.azure.appconfiguration.enabled | Whether enable spring-cloud-azure-
 spring.cloud.azure.appconfiguration.default-context | Default context path to load properties from | No | application
 spring.cloud.azure.appconfiguration.name | Alternative to Spring application name, if not configured, fallback to default Spring application name | No | ${spring.application.name}
 spring.cloud.azure.appconfiguration.profile-separator | Profile separator for the key name, e.g., /foo-app_dev/db.connection.key, must follow format `^[a-zA-Z0-9_@]+$` | No | `_`
-spring.cloud.azure.appconfiguration.fail-fast | Whether throw RuntimeException or not when exception occurs | No |  true
 spring.cloud.azure.appconfiguration.cache-expiration | Amount of time, of type [Duration](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-conversion-duration), configurations are stored before a check can occur. | No | 30s
 spring.cloud.azure.appconfiguration.managed-identity.client-id | Client id of the user assigned managed identity, only required when choosing to use user assigned managed identity on Azure | No | null
 
@@ -48,6 +47,7 @@ spring.cloud.azure.appconfiguration.stores[0].endpoint | Endpoint of the configu
 spring.cloud.azure.appconfiguration.stores[0].prefix | The prefix of the key name in the configuration store, e.g., /my-prefix/application/key.name | No |  null
 spring.cloud.azure.appconfiguration.stores[0].connection-string | Required when `name` is empty, otherwise, can be loaded automatically on Azure Virtual Machine or App Service | Conditional | null
 spring.cloud.azure.appconfiguration.stores[0].label | Comma separated list of label values, by default will query empty labeled value. If you want to specify *empty*(null) label explicitly, use `%00`, e.g., spring.cloud.azure.appconfiguration.stores[0].label=%00,v0 | No |  null
+spring.cloud.azure.appconfiguration.stores[0].fail-fast | Whether throw RuntimeException or not when exception occurs. If an exception does occur when false the store is skipped. | No |  true
 spring.cloud.azure.appconfiguration.stores[0].watched-key | The single watched key(or by default *) used to indicate configuration change.  | No | *
 
 ## Advanced usage
@@ -98,7 +98,7 @@ For web applications a refresh will be attempted whenever a ServletRequestHandle
 
 ### Failfast
 
-Failfast feature decides whether throw RuntimeException or not when exception happens. By default, failfast is enabled, it can be disabled with below configuration:
+Failfast feature decides whether throw RuntimeException or not when exception happens. If an exception does occur when false the store is skipped. Any store skipped on startup will be automatically skipped on Refresh. By default, failfast is enabled, it can be disabled with below configuration:
 
 ```properties
 spring.cloud.azure.appconfiguration.fail-fast=false


### PR DESCRIPTION
## Description
On Startup now any failure in loading a config store will result in stopping the load of a config store. The fail-fast configuration has been moved to a store level. Fail-fast can be thought of marking a store as required. An error in a fail fast true store will result in the application stopping. An error in a fail fast false store results in the store being skipped.

Fail Fast is no long used on refresh. Any store skipped in startup will not load during refresh. An error on refresh will just wait to the updated cache-expiration time to expire again.

## Todos
- [x] Tests
- [ ] Documentation
