### PR TITLE
Update message usage for 2.0 azure service bus

### DIFF
--- a/spring-integration-azure/spring-integration-azure-core/src/main/java/com/microsoft/azure/spring/integration/core/converter/AbstractAzureMessageConverter.java
+++ b/spring-integration-azure/spring-integration-azure-core/src/main/java/com/microsoft/azure/spring/integration/core/converter/AbstractAzureMessageConverter.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public abstract class AbstractAzureMessageConverter<T> implements AzureMessageConverter<T> {
     private static ObjectMapper objectMapper = new ObjectMapper();
 
-    private static byte[] toPayload(Object object) {
+    protected static byte[] toPayload(Object object) {
         try {
             return objectMapper.writeValueAsBytes(object);
         } catch (JsonProcessingException e) {

--- a/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/converter/ServiceBusMessageConverter.java
+++ b/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/converter/ServiceBusMessageConverter.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.spring.integration.servicebus.converter;
 
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.Message;
+import com.microsoft.azure.servicebus.MessageBody;
 import com.microsoft.azure.spring.integration.core.AzureHeaders;
 import com.microsoft.azure.spring.integration.core.converter.AbstractAzureMessageConverter;
 import org.slf4j.Logger;
@@ -33,7 +34,21 @@ public class ServiceBusMessageConverter extends AbstractAzureMessageConverter<IM
 
     @Override
     protected byte[] getPayload(IMessage azureMessage) {
-        return azureMessage.getBody();
+        MessageBody messageBody = azureMessage.getMessageBody();
+        if (messageBody == null) {
+            return null;
+        }
+
+        switch (messageBody.getBodyType()) {
+            case BINARY:
+                return messageBody.getBinaryData().stream().findFirst().orElse(null);
+            case VALUE:
+                return String.valueOf(messageBody.getValueData()).getBytes();
+            case SEQUENCE:
+                return toPayload(messageBody.getSequenceData().stream().findFirst().orElse(null));
+            default:
+                return null;
+        }
     }
 
     @Override

--- a/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/converter/ServiceBusMessageConverter.java
+++ b/spring-integration-azure/spring-integration-servicebus/src/main/java/com/microsoft/azure/spring/integration/servicebus/converter/ServiceBusMessageConverter.java
@@ -69,20 +69,20 @@ public class ServiceBusMessageConverter extends AbstractAzureMessageConverter<IM
 
             if (contentType instanceof MimeType) {
                 serviceBusMessage.setContentType(((MimeType) contentType).toString());
-            } else /* contentType is String */ {
+            } else {
                 serviceBusMessage.setContentType((String) contentType);
             }
         }
 
         if (headers.containsKey(MessageHeaders.ID)) {
-            serviceBusMessage.setMessageId(headers.get(MessageHeaders.ID, UUID.class).toString());
+            serviceBusMessage.setMessageId(String.valueOf(headers.get(MessageHeaders.ID, UUID.class)));
         }
 
         if (headers.containsKey(MessageHeaders.REPLY_CHANNEL)) {
             serviceBusMessage.setReplyTo(headers.get(MessageHeaders.REPLY_CHANNEL, String.class));
         }
 
-        headers.entrySet().forEach(e->serviceBusMessage.getProperties().put(e.getKey(), e.getValue().toString()));
+        headers.forEach((key, value) -> serviceBusMessage.getProperties().put(key, value.toString()));
     }
 
     @Override

--- a/spring-integration-azure/spring-integration-servicebus/src/test/java/com/microsoft/azure/spring/integration/servicebus/ServiceBusMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-servicebus/src/test/java/com/microsoft/azure/spring/integration/servicebus/ServiceBusMessageConverterTest.java
@@ -6,14 +6,22 @@
 
 package com.microsoft.azure.spring.integration.servicebus;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.Message;
+import com.microsoft.azure.servicebus.MessageBody;
 import com.microsoft.azure.spring.integration.core.AzureHeaders;
 import com.microsoft.azure.spring.integration.core.converter.AzureMessageConverter;
 import com.microsoft.azure.spring.integration.servicebus.converter.ServiceBusMessageConverter;
 import com.microsoft.azure.spring.integration.test.support.AzureMessageConverterTest;
+import org.junit.Test;
 import org.springframework.messaging.MessageHeaders;
 
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -44,5 +52,50 @@ public class ServiceBusMessageConverterTest extends AzureMessageConverterTest<IM
         assertNotNull(message.getHeaders().get(headerProperties, String.class));
         assertEquals(serviceBusMessage.getProperties().get(headerProperties),
                 message.getHeaders().get(headerProperties, String.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRaiseIllegalIfPayloadNull() {
+        IMessage message = new Message((MessageBody) null);
+
+        getConverter().toMessage(message, byte[].class);
+    }
+
+    @Test
+    public void shouldConvertIMessageBinaryIntoAMessage() {
+        IMessage message = new Message(this.payload.getBytes());
+
+        org.springframework.messaging.Message<byte[]> convertedPayload =
+                getConverter().toMessage(message, byte[].class);
+
+        assertNotNull(convertedPayload);
+        assertArrayEquals(convertedPayload.getPayload(), payload.getBytes());
+    }
+
+    @Test
+    public void shouldConvertIMessageValueIntoAMessage() {
+        IMessage message = new Message(MessageBody.fromValueData(this.payload));
+
+        org.springframework.messaging.Message<byte[]> convertedPayload =
+                getConverter().toMessage(message, byte[].class);
+
+        assertNotNull(convertedPayload);
+        assertArrayEquals(convertedPayload.getPayload(), payload.getBytes());
+    }
+
+    @Test
+    public void shouldConvertIMessageSequenceIntoAMessage() throws JsonProcessingException {
+        List<Object> internalSequence = singletonList(payload);
+        List<List<Object>> sequences = singletonList(internalSequence);
+
+        IMessage message = new Message(MessageBody.fromSequenceData(sequences));
+
+        org.springframework.messaging.Message<byte[]> convertedPayload =
+                getConverter().toMessage(message, byte[].class);
+
+        assertNotNull(convertedPayload);
+        assertArrayEquals(
+                convertedPayload.getPayload(),
+                new ObjectMapper().writeValueAsBytes(internalSequence));
     }
 }


### PR DESCRIPTION
## Description
Update the usage to get message body from Azure Service Bus messages.

## Related PRs
https://github.com/Azure/azure-service-bus-java/pull/296

## Todos
- [x] Tests

## Steps to Test
Creating a new event manually as a String using some tools as Cerebrata Cerulean
![image](https://user-images.githubusercontent.com/1384848/76059114-e3054b80-5f32-11ea-8449-75b395493a89.png)
And, try to consume the message. They will arrive as a VALUE instead of BINARY.

**Other way to simulate is:**
Using this code sample, https://github.com/Azure-Samples/spring-jms-service-bus.git, add  a message converter to instead of use a binary message use a text Message.
```java
@Component
public class UserConverter implements MessageConverter {
    @Override
    public Message toMessage(Object object, Session session)
            throws JMSException {
        String payload = null;
        try {
            payload = new ObjectMapper().writeValueAsString(object);
        } catch (JsonProcessingException e) {
            e.printStackTrace();
        }

        return session.createTextMessage(payload);
    }
...
}
```
