### PR TITLE
Enable errorChannel feature to Azure Service Bus

### DIFF
--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusQueueMessageChannelBinder.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusQueueMessageChannelBinder.java
@@ -9,9 +9,7 @@ package com.microsoft.azure.servicebus.stream.binder;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusConsumerProperties;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusQueueExtendedBindingProperties;
 import com.microsoft.azure.servicebus.stream.binder.provisioning.ServiceBusChannelProvisioner;
-import com.microsoft.azure.spring.integration.core.api.CheckpointConfig;
 import com.microsoft.azure.spring.integration.core.api.SendOperation;
-import com.microsoft.azure.spring.integration.servicebus.ServiceBusClientConfig;
 import com.microsoft.azure.spring.integration.servicebus.inbound.ServiceBusQueueInboundChannelAdapter;
 import com.microsoft.azure.spring.integration.servicebus.queue.ServiceBusQueueOperation;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
@@ -38,11 +36,14 @@ public class ServiceBusQueueMessageChannelBinder extends
     @Override
     protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
             ExtendedConsumerProperties<ServiceBusConsumerProperties> properties) {
+
         this.serviceBusQueueOperation.setCheckpointConfig(buildCheckpointConfig(properties));
         this.serviceBusQueueOperation.setClientConfig(buildClientConfig(properties));
         ServiceBusQueueInboundChannelAdapter inboundAdapter =
                 new ServiceBusQueueInboundChannelAdapter(destination.getName(), this.serviceBusQueueOperation);
         inboundAdapter.setBeanFactory(getBeanFactory());
+        ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination, group, properties);
+        inboundAdapter.setErrorChannel(errorInfrastructure.getErrorChannel());
         return inboundAdapter;
     }
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusMessageChannelBinder.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-stream-binder-core/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusMessageChannelBinder.java
@@ -45,6 +45,7 @@ public abstract class ServiceBusMessageChannelBinder<T extends ServiceBusExtende
         handler.setBeanFactory(getBeanFactory());
         handler.setSync(producerProperties.getExtension().isSync());
         handler.setSendTimeout(producerProperties.getExtension().getSendTimeout());
+        handler.setSendFailureChannel(errorChannel);
         if (producerProperties.isPartitioned()) {
             handler.setPartitionKeyExpressionString(
                     "'partitionKey-' + headers['" + BinderHeaders.PARTITION_HEADER + "']");

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicMessageChannelBinder.java
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/src/main/java/com/microsoft/azure/servicebus/stream/binder/ServiceBusTopicMessageChannelBinder.java
@@ -9,7 +9,6 @@ package com.microsoft.azure.servicebus.stream.binder;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusConsumerProperties;
 import com.microsoft.azure.servicebus.stream.binder.properties.ServiceBusTopicExtendedBindingProperties;
 import com.microsoft.azure.servicebus.stream.binder.provisioning.ServiceBusChannelProvisioner;
-import com.microsoft.azure.spring.integration.core.api.CheckpointConfig;
 import com.microsoft.azure.spring.integration.core.api.SendOperation;
 import com.microsoft.azure.spring.integration.servicebus.inbound.ServiceBusTopicInboundChannelAdapter;
 import com.microsoft.azure.spring.integration.servicebus.topic.ServiceBusTopicOperation;
@@ -50,6 +49,8 @@ public class ServiceBusTopicMessageChannelBinder extends
         ServiceBusTopicInboundChannelAdapter inboundAdapter =
                 new ServiceBusTopicInboundChannelAdapter(destination.getName(), this.serviceBusTopicOperation, group);
         inboundAdapter.setBeanFactory(getBeanFactory());
+        ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination, group, properties);
+        inboundAdapter.setErrorChannel(errorInfrastructure.getErrorChannel());
         return inboundAdapter;
     }
 


### PR DESCRIPTION
## Description
Provide support for a global error channel from  Spring Cloud Stream

## Related PRs
PR to apply to Azure Event Hub: https://github.com/microsoft/spring-cloud-azure/pull/547

## Steps to Test
Create an errorChannel listen and simulate an error during consuming a message.

```java
@StreamListener("errorChannel")
public void error(Message<?> message) {
	System.out.println("Handling ERROR: " + message);
}
```
