### PR TITLE
Make eventhub checkpoint storage container creation backward compatible

### DIFF
--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/DefaultEventHubClientFactoryTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/DefaultEventHubClientFactoryTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
@@ -87,6 +88,7 @@ public class DefaultEventHubClientFactoryTest {
         when(eventHubClientBuilder.buildAsyncConsumerClient()).thenReturn(this.eventHubConsumerClient);
         when(eventHubClientBuilder.buildAsyncProducerClient()).thenReturn(this.eventHubProducerClient);
         when(blobContainerClientBuilder.buildAsyncClient()).thenReturn(this.blobContainerClient);
+        when(this.blobContainerClient.exists()).thenReturn(Mono.just(true));
         when(eventProcessorClientBuilder.buildEventProcessorClient()).thenReturn(this.eventProcessorClient);
         when(connectionStringProvider.getConnectionString()).thenReturn(connectionString);
 


### PR DESCRIPTION
## Description
When we use track one Event Hub library, we set the Event Hub name as the container name for checkpointing. And the EventHubProcessor library will create the container automatically if not exists. As we migrate to track two Event Hub library, the auto-creation of container behavior is changed, so I add the code snippet to create the container if not exists.

```java
final Boolean isContainerExist = blobClient.exists().block();
if (isContainerExist == null || !isContainerExist) {
    LOGGER.warn("Will create storage blob {}, the auto creation might be deprecated in later versions.",
            containerName);
    blobClient.create().block(Duration.ofMinutes(5L));
}
```

As for backward compatibility, we'll still use the Event Hub name as the container name if no container name provided. But I strongly suggest that users provide their own container name since the storage hierarchy would be like `{containerName}/{eventhub namespace}/{eventhub name}/{consumer group}/partition`.



## Related PRs
List related PRs against other branches:



## Todos
- [X] Tests
- [X] Documentation

## Steps to Test

