### PR TITLE
Null ETag Fix App Configuration

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
@@ -137,7 +137,7 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
 
         List<ConfigurationSetting> items = clientStore.listSettingRevisons(settingSelector, store.getEndpoint());
 
-        String etag = "";
+        String etag = null;
         // If there is no result, etag will be considered empty.
         // A refresh will trigger once the selector returns a value.
         if (items != null && !items.isEmpty()) {
@@ -145,15 +145,14 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
         }
 
         if (StateHolder.getEtagState(storeNameWithSuffix) == null) {
-            // Should never be the case as Property Source should set the state, but if
-            // etag != null return true.
+            // On startup there was no Configurations, but now there is.
             if (etag != null) {
                 return true;
             }
             return false;
         }
 
-        if (!etag.equals(StateHolder.getEtagState(storeNameWithSuffix).getETag())) {
+        if (etag != null && !etag.equals(StateHolder.getEtagState(storeNameWithSuffix).getETag())) {
             LOGGER.trace("Some keys in store [{}] matching [{}] is updated, will send refresh event.",
                     store.getEndpoint(), watchedKeyNames);
             if (this.eventDataInfo.isEmpty()) {


### PR DESCRIPTION
## Description
Set eTag to Null instead of empty String and fixes null check. Added tests.

Fixes: https://github.com/Azure/AppConfiguration/issues/298
