### PR TITLE
Fixes bug where the number of labels was at max 5.

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.endpoint.event.RefreshEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.util.StringUtils;
 
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
 import com.azure.data.appconfiguration.models.SettingSelector;
@@ -133,7 +132,7 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
     private boolean refresh(ConfigStore store, String storeSuffix, String watchedKeyNames) {
         String storeNameWithSuffix = store.getEndpoint() + storeSuffix;
         SettingSelector settingSelector = new SettingSelector().setKeyFilter(watchedKeyNames)
-                .setLabelFilter(StringUtils.arrayToCommaDelimitedString(store.getLabels()));
+                .setLabelFilter("*");
 
         List<ConfigurationSetting> items = clientStore.listSettingRevisons(settingSelector, store.getEndpoint());
 

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceKeyVaultTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceKeyVaultTest.java
@@ -30,10 +30,8 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -132,12 +130,10 @@ public class AppConfigurationPropertySourceKeyVaultTest {
         appProperties.setMaxRetryTime(0);
         ConfigStore testStore = new ConfigStore();
         testStore.setEndpoint(TEST_STORE_NAME);
-        Map<String, List<String>> storeContextsMap = new HashMap<String, List<String>>();
         ArrayList<String> contexts = new ArrayList<String>();
         contexts.add("/application/*");
-        storeContextsMap.put(TEST_STORE_NAME, contexts);
         propertySource = new AppConfigurationPropertySource(TEST_CONTEXT, testStore, "\0",
-                appConfigurationProperties, clientStoreMock, appProperties, tokenCredentialProvider, storeContextsMap);
+                appConfigurationProperties, clientStoreMock, appProperties, tokenCredentialProvider);
 
         testItems = new ArrayList<ConfigurationSetting>();
         testItems.add(item1);

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceTest.java
@@ -157,12 +157,10 @@ public class AppConfigurationPropertySourceTest {
         appProperties = new AppConfigurationProviderProperties();
         ConfigStore configStore = new ConfigStore();
         configStore.setEndpoint(TEST_STORE_NAME);
-        Map<String, List<String>> storeContextsMap = new HashMap<String, List<String>>();
         ArrayList<String> contexts = new ArrayList<String>();
         contexts.add("/application/*");
-        storeContextsMap.put(TEST_STORE_NAME, contexts);
         propertySource = new AppConfigurationPropertySource(TEST_CONTEXT, configStore, "\0",
-                appConfigurationProperties, clientStoreMock, appProperties, tokenCredentialProvider, storeContextsMap);
+                appConfigurationProperties, clientStoreMock, appProperties, tokenCredentialProvider);
 
         testItems = new ArrayList<ConfigurationSetting>();
         testItems.add(item1);
@@ -181,8 +179,7 @@ public class AppConfigurationPropertySourceTest {
     public void testPropCanBeInitAndQueried() throws IOException {
         when(clientStoreMock.listSettings(Mockito.any(), Mockito.anyString())).thenReturn(testItems)
                 .thenReturn(FEATURE_ITEMS);
-        when(clientStoreMock.listSettingRevisons(Mockito.any(), Mockito.anyString())).thenReturn(testItems)
-                .thenReturn(FEATURE_ITEMS);
+        
         FeatureSet featureSet = new FeatureSet();
         try {
             propertySource.initProperties(featureSet);


### PR DESCRIPTION
## Description
The kv endpoint maxes out at 5 labels. This updates it so revisions checks against * labels. Also the revisions check is moved up a level so there is 1 revisions check per store not per label.