### PR TITLE
App Config Revisions Pagination Fix

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
@@ -220,23 +220,22 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
             String watchedKeyNames = clients.watchedKeyNames(store, storeContextsMap);
             SettingSelector settingSelector = new SettingSelector().setKeyFilter(watchedKeyNames).setLabelFilter("*");
 
-            List<ConfigurationSetting> configurationRevisions = clients.listSettingRevisons(settingSelector,
+            ConfigurationSetting configurationRevision = clients.getRevison(settingSelector,
                     store.getEndpoint());
 
             settingSelector = new SettingSelector().setKeyFilter(FEATURE_STORE_WATCH_KEY).setLabelFilter("*");
 
-            List<ConfigurationSetting> featureRevisions = clients.listSettingRevisons(settingSelector,
+            ConfigurationSetting featureRevision = clients.getRevison(settingSelector,
                     store.getEndpoint());
 
-            if (configurationRevisions != null && !configurationRevisions.isEmpty()) {
-                StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX,
-                        configurationRevisions.get(0));
+            if (configurationRevision != null) {
+                StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX, configurationRevision);
             } else {
                 StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX, new ConfigurationSetting());
             }
 
-            if (featureRevisions != null && !featureRevisions.isEmpty()) {
-                StateHolder.setEtagState(store.getEndpoint() + FEATURE_SUFFIX, featureRevisions.get(0));
+            if (featureRevision != null) {
+                StateHolder.setEtagState(store.getEndpoint() + FEATURE_SUFFIX, featureRevision);
             } else {
                 StateHolder.setEtagState(store.getEndpoint() + FEATURE_SUFFIX, new ConfigurationSetting());
             }

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
@@ -134,13 +134,13 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
         SettingSelector settingSelector = new SettingSelector().setKeyFilter(watchedKeyNames)
                 .setLabelFilter("*");
 
-        List<ConfigurationSetting> items = clientStore.listSettingRevisons(settingSelector, store.getEndpoint());
+        ConfigurationSetting revision = clientStore.getRevison(settingSelector, store.getEndpoint());
 
         String etag = null;
         // If there is no result, etag will be considered empty.
         // A refresh will trigger once the selector returns a value.
-        if (items != null && !items.isEmpty()) {
-            etag = items.get(0).getETag();
+        if (revision != null) {
+            etag = revision.getETag();
         }
 
         if (StateHolder.getEtagState(storeNameWithSuffix) == null) {

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
@@ -83,7 +83,8 @@ public class ClientStore {
             // Connection String
             builder.connectionString(connection.getConnectionString());
         } else if (connection.getEndpoint() != null) {
-            // System Assigned Identity. Needs to be checked last as all of the above should have a Endpoint.
+            // System Assigned Identity. Needs to be checked last as all of the above
+            // should have a Endpoint.
             ManagedIdentityCredentialBuilder micBuilder = new ManagedIdentityCredentialBuilder();
             builder.credential(micBuilder.build());
         } else {
@@ -93,7 +94,7 @@ public class ClientStore {
     }
 
     /**
-     * Gets a list of Configuration Settings from the revisions given config store that
+     * Gets the latest Configuration Setting from the revisions given config store that
      * match the Setting Selector criteria.
      * 
      * @param settingSelector Information on which setting to pull. i.e. number of
@@ -101,9 +102,9 @@ public class ClientStore {
      * @param storeName Name of the App Configuration store to query against.
      * @return List of Configuration Settings.
      */
-    public final List<ConfigurationSetting> listSettingRevisons(SettingSelector settingSelector, String storeName) {
+    public final ConfigurationSetting getRevison(SettingSelector settingSelector, String storeName) {
         ConfigurationAsyncClient client = buildClient(storeName);
-        return client.listRevisions(settingSelector).collectList().block();
+        return client.listRevisions(settingSelector).blockFirst();
     }
 
     /**

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
@@ -12,17 +12,11 @@ import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_CONN_ST
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_CONN_STRING_2;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_CONTEXT;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_KEY_1;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_KEY_2;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_KEY_3;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_LABEL_1;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_LABEL_2;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_LABEL_3;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_NAME;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_NAME_1;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_STORE_NAME_2;
 import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_VALUE_1;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_VALUE_2;
-import static com.microsoft.azure.spring.cloud.config.TestConstants.TEST_VALUE_3;
 import static com.microsoft.azure.spring.cloud.config.TestUtils.createItem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -40,7 +34,6 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,8 +62,6 @@ public class AppConfigurationPropertySourceLocatorTest {
     private static final String PROFILE_NAME_2 = "prod";
 
     private static final String PREFIX = "/config";
-
-    public static final List<ConfigurationSetting> FEATURE_ITEMS = new ArrayList<>();
 
     private static final ConfigurationSetting featureItem = createItem(".appconfig.featureflag/", "Alpha",
             FEATURE_VALUE, FEATURE_LABEL, FEATURE_FLAG_CONTENT_TYPE);
@@ -128,21 +119,8 @@ public class AppConfigurationPropertySourceLocatorTest {
     
     private static final String EMPTY_CONTENT_TYPE = "";
     
-    public List<ConfigurationSetting> testItems = new ArrayList<>();
-    
     private static final ConfigurationSetting item1 = createItem(TEST_CONTEXT, TEST_KEY_1, TEST_VALUE_1, TEST_LABEL_1,
             EMPTY_CONTENT_TYPE);
-
-    private static final ConfigurationSetting item2 = createItem(TEST_CONTEXT, TEST_KEY_2, TEST_VALUE_2, TEST_LABEL_2,
-            EMPTY_CONTENT_TYPE);
-
-    private static final ConfigurationSetting item3 = createItem(TEST_CONTEXT, TEST_KEY_3, TEST_VALUE_3, TEST_LABEL_3,
-            EMPTY_CONTENT_TYPE);
-
-    @BeforeClass
-    public static void init() {
-        FEATURE_ITEMS.add(featureItem);
-    }
 
     @Before
     public void setup() {
@@ -172,11 +150,6 @@ public class AppConfigurationPropertySourceLocatorTest {
         appProperties.setVersion("1.0");
         appProperties.setMaxRetries(12);
         appProperties.setMaxRetryTime(0);
-        
-        testItems = new ArrayList<ConfigurationSetting>();
-        testItems.add(item1);
-        testItems.add(item2);
-        testItems.add(item3);
     }
 
     @After
@@ -217,8 +190,8 @@ public class AppConfigurationPropertySourceLocatorTest {
         labels[0] = "\0";
         when(configStoreMock.getLabels()).thenReturn(labels);
         when(properties.getDefaultContext()).thenReturn("application");
-        when(clientStoreMock.listSettingRevisons(Mockito.any(), Mockito.anyString())).thenReturn(testItems)
-        .thenReturn(FEATURE_ITEMS);
+        when(clientStoreMock.getRevison(Mockito.any(), Mockito.anyString())).thenReturn(item1)
+        .thenReturn(featureItem);
 
         locator = new AppConfigurationPropertySourceLocator(properties, appProperties, clientStoreMock,
                 tokenCredentialProvider);


### PR DESCRIPTION
## Description
Fixes Issues where stores with a long history would make multiple requests to get all of the history when only the first item is needed. 