### PR TITLE
App Config Store Partial Load Fix

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
@@ -137,28 +137,35 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
         // There is only one Feature Set for all AppConfigurationPropertySources
         FeatureSet featureSet = new FeatureSet();
 
+        List<AppConfigurationPropertySource> sourceList = new ArrayList<AppConfigurationPropertySource>();
+
         // Reverse in order to add Profile specific properties earlier, and last profile
         // comes first
         Collections.reverse(contexts);
         for (String sourceContext : contexts) {
             try {
-                List<AppConfigurationPropertySource> sourceList = create(sourceContext, store, storeContextsMap,
-                        initFeatures, featureSet);
-                sourceList.forEach(composite::addPropertySource);
+                sourceList.addAll(create(sourceContext, store, storeContextsMap, initFeatures, featureSet));
+
                 LOGGER.debug("PropertySource context [{}] is added.", sourceContext);
             } catch (Exception e) {
                 if (store.isFailFast() || !startup) {
                     LOGGER.error(
                             "Fail fast is set and there was an error reading configuration from Azure App "
-                                    + "Configuration Service for " + sourceContext);
+                                    + "Configuration store " + store.getEndpoint()
+                                    + ". The configuration starting with " + sourceContext + " failed to load.");
                     ReflectionUtils.rethrowRuntimeException(e);
                 } else {
-                    LOGGER.warn("Unable to load configuration from Azure AppConfiguration Service for " + sourceContext,
+                    LOGGER.warn(
+                            "Unable to load configuration from Azure AppConfiguration store " + store.getEndpoint()
+                                    + ". The configurations starting with " + sourceContext + "failed to load.",
                             e);
                     StateHolder.setLoadState(store.getEndpoint(), false);
                 }
+                // If anything breaks we skip out on loading the rest of the store.
+                return;
             }
         }
+        sourceList.forEach(composite::addPropertySource);
     }
 
     private List<String> generateContexts(String applicationName, List<String> profiles, ConfigStore configStore) {

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
@@ -102,6 +102,9 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
                             // Refresh Feature Flags
                             willRefresh = refresh(configStore, FEATURE_SUFFIX, FEATURE_STORE_WATCH_KEY) ? true
                                     : willRefresh;
+                        } else {
+                            LOGGER.debug("Skipping refresh check for " + configStore.getEndpoint()
+                                    + ". The store failed to load on startup.");
                         }
                     }
                     // Resetting last Checked date to now.

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefresh.java
@@ -113,6 +113,11 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
                 if (willRefresh) {
                     // Only one refresh Event needs to be call to update all of the
                     // stores, not one for each.
+                    if (eventDataInfo.equals("*")) {
+                        LOGGER.info("Configuration Refresh event triggered by store modification.");
+                    } else {
+                        LOGGER.info("Configuration Refresh Event triggered by " + eventDataInfo);
+                    }
                     RefreshEventData eventData = new RefreshEventData(eventDataInfo);
                     publisher.publishEvent(new RefreshEvent(this, eventData, eventData.getMessage()));
                 }
@@ -149,6 +154,7 @@ public class AppConfigurationRefresh implements ApplicationEventPublisherAware {
         if (StateHolder.getEtagState(storeNameWithSuffix) == null) {
             // On startup there was no Configurations, but now there is.
             if (etag != null) {
+                LOGGER.info("The store " + store.getEndpoint() + " had no keys on startup, but now has keys to load.");
                 return true;
             }
             return false;

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
@@ -25,11 +27,13 @@ import com.azure.data.appconfiguration.models.SettingSelector;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.microsoft.azure.spring.cloud.config.AppConfigurationCredentialProvider;
 import com.microsoft.azure.spring.cloud.config.AppConfigurationProviderProperties;
+import com.microsoft.azure.spring.cloud.config.AppConfigurationRefresh;
 import com.microsoft.azure.spring.cloud.config.pipline.policies.BaseAppConfigurationPolicy;
 import com.microsoft.azure.spring.cloud.config.resource.Connection;
 import com.microsoft.azure.spring.cloud.config.resource.ConnectionPool;
 
 public class ClientStore {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientStore.class);
 
     private AppConfigurationProviderProperties appProperties;
 
@@ -72,18 +76,24 @@ public class ClientStore {
 
         if (tokenCredential != null) {
             // User Provided Token Credential
+            LOGGER.debug("Connecting to " + endpoint + " using AppConfigurationCredentialProvider.");
             builder.credential(tokenCredential);
         } else if ((connection.getClientId() != null && StringUtils.isNotEmpty(connection.getClientId()))
                 && connection.getEndpoint() != null) {
             // User Assigned Identity - Client ID through configuration file.
+            LOGGER.debug("Connecting to " + endpoint + " using Client ID from configuration file.");
             ManagedIdentityCredentialBuilder micBuilder = new ManagedIdentityCredentialBuilder()
                     .clientId(connection.getClientId());
             builder.credential(micBuilder.build());
         } else if (StringUtils.isNotEmpty(connection.getConnectionString())) {
             // Connection String
+            LOGGER.debug("Connecting to " + endpoint + " using Connecting String.");
             builder.connectionString(connection.getConnectionString());
         } else if (connection.getEndpoint() != null) {
-            // System Assigned Identity. Needs to be checked last as all of the above should have a Endpoint.
+            // System Assigned Identity. Needs to be checked last as all of the above
+            // should have a Endpoint.
+            LOGGER.debug("Connecting to " + endpoint
+                    + " using Azure System Assigned Identity or Azure User Assigned Identity.");
             ManagedIdentityCredentialBuilder micBuilder = new ManagedIdentityCredentialBuilder();
             builder.credential(micBuilder.build());
         } else {

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocatorTest.java
@@ -355,7 +355,9 @@ public class AppConfigurationPropertySourceLocatorTest {
 
         PropertySource<?> source = locator.locate(environment);
         assertThat(source).isInstanceOf(CompositePropertySource.class);
-        verify(configStoreMock, times(3)).isFailFast();
+        
+        // Once a store fails it should stop attempting to load
+        verify(configStoreMock, times(1)).isFailFast();
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes a bug that allowed stores using both /application/ and /<app_name>/ to load when one of them fails, but then stopped refresh from triggering on that store.