### PR TITLE
Remove duplicate values from watch key request

### DIFF
--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/stores/ClientStore.java
@@ -161,7 +161,7 @@ public class ClientStore {
         String watchedKey = store.getWatchedKey().trim();
         List<String> contexts = storeContextsMap.get(store.getEndpoint());
 
-        String watchedKeys = contexts.stream().map(ctx -> genKey(ctx, watchedKey))
+        String watchedKeys = contexts.stream().map(ctx -> genKey(ctx, watchedKey)).distinct()
                 .collect(Collectors.joining(","));
 
         if (watchedKeys.contains(",") && watchedKeys.contains("*")) {

--- a/spring-cloud-azure-samples/azure-appconfiguration-sample/src/main/resources/bootstrap.yaml
+++ b/spring-cloud-azure-samples/azure-appconfiguration-sample/src/main/resources/bootstrap.yaml
@@ -4,6 +4,5 @@ spring:
   cloud:
     azure:
       appconfiguration:
-        cache-expiration: "60000"
         stores:
-          - connection-string: Endpoint=https://mametcal-app-config.azconfig.io;Id=CwzF-l3-s0:IwMKr+zTOO+RO2nHrXT0;Secret=2RdyHYymXZ2Z3SzxBs28GX4Y5mIV2oL1HeYzX8vdj4I=
+          - connection-string: ${CONFIG_STORE_CONNECTION_STRING}

--- a/spring-cloud-azure-samples/azure-appconfiguration-sample/src/main/resources/bootstrap.yaml
+++ b/spring-cloud-azure-samples/azure-appconfiguration-sample/src/main/resources/bootstrap.yaml
@@ -1,0 +1,9 @@
+# Use default application name and no profile configured
+# Keys starting with /application/ will be matched
+spring:
+  cloud:
+    azure:
+      appconfiguration:
+        cache-expiration: "60000"
+        stores:
+          - connection-string: Endpoint=https://mametcal-app-config.azconfig.io;Id=CwzF-l3-s0:IwMKr+zTOO+RO2nHrXT0;Secret=2RdyHYymXZ2Z3SzxBs28GX4Y5mIV2oL1HeYzX8vdj4I=

--- a/spring-cloud-azure-samples/azure-appconfiguration-sample/src/main/resources/bootstrap2.yaml
+++ b/spring-cloud-azure-samples/azure-appconfiguration-sample/src/main/resources/bootstrap2.yaml
@@ -1,8 +1,0 @@
-# Use default application name and no profile configured
-# Keys starting with /application/ will be matched
-spring:
-  cloud:
-    azure:
-      appconfiguration:
-        stores:
-          - connection-string: ${CONFIG_STORE_CONNECTION_STRING}


### PR DESCRIPTION
## Description
Watch Keys should have distinct values. Duplicates exist when using multiple labels. Causes issues when 6 or more watch keys exist.