### PR TITLE
modify readme for topic and queue stream binders for typos

### DIFF
--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/readme.md
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-queue-stream-binder/readme.md
@@ -99,7 +99,7 @@ Controls the max concurrent calls of service bus message handler and the size of
 
 Default: `1`
 
-**_sessionEnabled_**
+**_sessionsEnabled_**
 
 Controls if is a session aware consumer. Set it to `true` if is a queue with sessions enabled.
 

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/readme.md
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-servicebus-topic-stream-binder/readme.md
@@ -100,7 +100,7 @@ Controls the max concurrent calls of service bus message handler and the size of
 
 Default: `1`
 
-**_sessionEnabled_**
+**_sessionsEnabled_**
 
 Controls if is a session aware consumer. Set it to `true` if is a topic with sessions enabled.
 


### PR DESCRIPTION
update typos that in the readme.md of topic and queue stream binder, property name should be _sessionsEnabled_ instead of _sessionEnabled_.