### PR TITLE
Feature make retry options configurable (

### DIFF
--- a/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubAutoConfiguration.java
+++ b/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubAutoConfiguration.java
@@ -97,6 +97,6 @@ public class AzureEventHubAutoConfiguration {
         }
 
         return new DefaultEventHubClientFactory(connectionStringProvider, checkpointConnectionString,
-                eventHubProperties.getCheckpointContainer());
+                eventHubProperties.getCheckpointContainer(), eventHubProperties.getConsumerRetryOptions());
     }
 }

--- a/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubProperties.java
+++ b/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubProperties.java
@@ -6,12 +6,15 @@
 
 package com.microsoft.azure.spring.cloud.autoconfigure.eventhub;
 
+import com.azure.core.amqp.AmqpRetryMode;
+import com.azure.core.amqp.AmqpRetryOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.Pattern;
+import java.time.Duration;
 
 /**
  * @author Warren Zhu
@@ -31,6 +34,73 @@ public class AzureEventHubProperties {
     private String checkpointAccessKey;
 
     private String checkpointContainer;
+
+    // AQMP default retry option in seconds.
+    private int consumerTryTimeout = 60;
+
+    // AQMP default retry option in milli seconds.
+    private int consumerDelay = 800;
+
+    // AQMP default retry option in seconds.
+    private int consumerMaxDelay = 60;
+
+    // AQMP default retry option.
+    private String consumerRetryMode = "EXPONENTIAL";
+
+    // AQMP default retry option.
+    private int consumerMaxRetries = 3;
+
+    public int getConsumerTryTimeout() {
+        return consumerTryTimeout;
+    }
+
+    public void setConsumerTryTimeout(int consumerTryTimeout) {
+        this.consumerTryTimeout = consumerTryTimeout;
+    }
+
+    public int getConsumerDelay() {
+        return consumerDelay;
+    }
+
+    public void setConsumerDelay(int consumerDelay) {
+        this.consumerDelay = consumerDelay;
+    }
+
+    public int getConsumerMaxDelay() {
+        return consumerMaxDelay;
+    }
+
+    public void setConsumerMaxDelay(int consumerMaxDelay) {
+        this.consumerMaxDelay = consumerMaxDelay;
+    }
+
+    public String getConsumerRetryMode() {
+        return consumerRetryMode;
+    }
+
+    public void setConsumerRetryMode(String consumerRetryMode) {
+        this.consumerRetryMode = consumerRetryMode;
+    }
+
+    public int getConsumerMaxRetries() {
+        return consumerMaxRetries;
+    }
+
+    public void setConsumerMaxRetries(int consumerMaxRetries) {
+        this.consumerMaxRetries = consumerMaxRetries;
+    }
+
+    public AmqpRetryOptions getConsumerRetryOptions() {
+        AmqpRetryOptions amqpRetryOptions = new AmqpRetryOptions();
+
+        amqpRetryOptions.setDelay(Duration.ofMillis(consumerDelay));
+        amqpRetryOptions.setMaxDelay(Duration.ofSeconds(consumerMaxDelay));
+        amqpRetryOptions.setMaxRetries(consumerMaxRetries);
+        amqpRetryOptions.setTryTimeout(Duration.ofSeconds(consumerTryTimeout));
+        amqpRetryOptions.setMode(AmqpRetryMode.valueOf(this.consumerRetryMode));
+
+        return amqpRetryOptions;
+    }
 
     public String getNamespace() {
         return namespace;

--- a/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubProperties.java
+++ b/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubProperties.java
@@ -15,6 +15,8 @@ import org.springframework.validation.annotation.Validated;
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.Pattern;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * @author Warren Zhu
@@ -147,6 +149,12 @@ public class AzureEventHubProperties {
         if (!StringUtils.hasText(namespace) && !StringUtils.hasText(connectionString)) {
             throw new IllegalArgumentException("Either 'spring.cloud.azure.eventhub.namespace' or " +
                     "'spring.cloud.azure.eventhub.connection-string' should be provided");
+        }
+
+        try {
+            AmqpRetryMode.valueOf(this.consumerRetryMode);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("A valid value should be provided for 'spring.cloud.azure.eventhub.consumer-retry-mode'");
         }
     }
 }

--- a/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubProperties.java
+++ b/spring-cloud-azure-autoconfigure/src/main/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubProperties.java
@@ -154,7 +154,8 @@ public class AzureEventHubProperties {
         try {
             AmqpRetryMode.valueOf(this.consumerRetryMode);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("A valid value should be provided for 'spring.cloud.azure.eventhub.consumer-retry-mode'");
+            throw new IllegalArgumentException("A valid value should be provided for " +
+                "'spring.cloud.azure.eventhub.consumer-retry-mode'");
         }
     }
 }

--- a/spring-cloud-azure-autoconfigure/src/test/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubAutoConfigurationTest.java
+++ b/spring-cloud-azure-autoconfigure/src/test/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubAutoConfigurationTest.java
@@ -110,7 +110,9 @@ public class AzureEventHubAutoConfigurationTest {
             .withPropertyValues("spring.cloud.azure.eventhub.checkpoint-storage-account=sa1")
             .withPropertyValues("spring.cloud.azure.eventhub.consumer-max-delay=1500")
             .run(context -> {
-                AmqpRetryOptions retryOptions = context.getBean(AzureEventHubProperties.class).getConsumerRetryOptions();
+                AmqpRetryOptions retryOptions = context
+                    .getBean(AzureEventHubProperties.class)
+                    .getConsumerRetryOptions();
                 assertThat(retryOptions.getMaxDelay()).isEqualTo(Duration.ofSeconds(1500));
             });
     }
@@ -121,7 +123,9 @@ public class AzureEventHubAutoConfigurationTest {
             .withPropertyValues("spring.cloud.azure.eventhub.checkpoint-storage-account=sa1")
             .withPropertyValues("spring.cloud.azure.eventhub.consumer-try-timeout=100")
             .run(context -> {
-                AmqpRetryOptions retryOptions = context.getBean(AzureEventHubProperties.class).getConsumerRetryOptions();
+                AmqpRetryOptions retryOptions = context
+                    .getBean(AzureEventHubProperties.class)
+                    .getConsumerRetryOptions();
                 assertThat(retryOptions.getTryTimeout()).isEqualTo(Duration.ofSeconds(100));
             });
     }
@@ -132,7 +136,9 @@ public class AzureEventHubAutoConfigurationTest {
             .withPropertyValues("spring.cloud.azure.eventhub.checkpoint-storage-account=sa1")
             .withPropertyValues("spring.cloud.azure.eventhub.consumer-retry-mode=FIXED")
             .run(context -> {
-                AmqpRetryOptions retryOptions = context.getBean(AzureEventHubProperties.class).getConsumerRetryOptions();
+                AmqpRetryOptions retryOptions = context
+                    .getBean(AzureEventHubProperties.class)
+                    .getConsumerRetryOptions();
                 assertThat(retryOptions.getMode()).isEqualTo(AmqpRetryMode.FIXED);
             });
     }

--- a/spring-cloud-azure-autoconfigure/src/test/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubAutoConfigurationTest.java
+++ b/spring-cloud-azure-autoconfigure/src/test/java/com/microsoft/azure/spring/cloud/autoconfigure/eventhub/AzureEventHubAutoConfigurationTest.java
@@ -99,7 +99,9 @@ public class AzureEventHubAutoConfigurationTest {
             .withPropertyValues("spring.cloud.azure.eventhub.checkpoint-storage-account=sa1")
             .withPropertyValues("spring.cloud.azure.eventhub.consumer-delay=1500")
             .run(context -> {
-                AmqpRetryOptions retryOptions = context.getBean(AzureEventHubProperties.class).getConsumerRetryOptions();
+                AmqpRetryOptions retryOptions = context
+                    .getBean(AzureEventHubProperties.class)
+                    .getConsumerRetryOptions();
                 assertThat(retryOptions.getDelay()).isEqualTo(Duration.ofMillis(1500));
             });
     }

--- a/spring-cloud-azure-stream-binder/spring-cloud-azure-eventhubs-stream-binder/README.md
+++ b/spring-cloud-azure-stream-binder/spring-cloud-azure-eventhubs-stream-binder/README.md
@@ -65,6 +65,19 @@ Name | Description | Required | Default
  spring.cloud.azure.eventhub.namespace | Event Hub Namespace. Auto creating if missing | Yes |
  spring.cloud.azure.eventhub.checkpoint-storage-account | StorageAccount name for checkpoint message successfully consumed | Yes
 
+#### Consumer retry options ####
+
+The consumer retry policy can be controlled by following paramters.
+
+Name | Description | Required | Default 
+---|---|---|---
+ spring.cloud.azure.eventhub.consumer-try-timeout | Sets the maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry. In *seconds* | No | 60
+ spring.cloud.azure.eventhub.consumer-delay | Gets the delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-approach. In *milli seconds* | No | 800
+ spring.cloud.azure.eventhub.consumer-max-delay | Sets the maximum permissible delay between retry attempts. In *seconds* | No | 60
+ spring.cloud.azure.eventhub.consumer-retry-mode | Sets the approach to use for calculating retry delays. *Exponential*: Retry attempts will delay based on a backoff strategy, where each attempt will increase the duration that it waits before retrying. *Fixed*: Retry attempts happen at fixed intervals; each delay is a consistent duration. | No | EXPONENTIAL
+ spring.cloud.azure.eventhub.consumer-max-retries | Sets the maximum number of retry attempts before considering the associated operation to have failed. | No | 3
+
+
  #### Event Hub Producer Properties ####
 
  It supports the following configurations with the format of `spring.cloud.stream.eventhub.bindings.<channelName>.producer`.

--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/factory/DefaultEventHubClientFactory.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/factory/DefaultEventHubClientFactory.java
@@ -62,8 +62,11 @@ public class DefaultEventHubClientFactory implements EventHubClientFactory, Disp
     private final EventHubConnectionStringProvider connectionStringProvider;
     private final AmqpRetryOptions retryOptions;
 
-    public DefaultEventHubClientFactory(@NonNull EventHubConnectionStringProvider connectionStringProvider,
-            String checkpointConnectionString, String checkpointStorageContainer) {
+    public DefaultEventHubClientFactory(
+        @NonNull EventHubConnectionStringProvider connectionStringProvider,
+        String checkpointConnectionString,
+        String checkpointStorageContainer
+    ) {
         Assert.hasText(checkpointConnectionString, "checkpointConnectionString can't be null or empty");
         this.connectionStringProvider = connectionStringProvider;
         this.checkpointStorageConnectionString = checkpointConnectionString;
@@ -71,8 +74,12 @@ public class DefaultEventHubClientFactory implements EventHubClientFactory, Disp
         this.retryOptions = new AmqpRetryOptions();
     }
 
-    public DefaultEventHubClientFactory(@NonNull EventHubConnectionStringProvider connectionStringProvider,
-                                        String checkpointConnectionString, String checkpointStorageContainer, AmqpRetryOptions retryOptions) {
+    public DefaultEventHubClientFactory(
+        @NonNull EventHubConnectionStringProvider connectionStringProvider,
+        String checkpointConnectionString,
+        String checkpointStorageContainer,
+        AmqpRetryOptions retryOptions
+    ) {
         Assert.hasText(checkpointConnectionString, "checkpointConnectionString can't be null or empty");
         this.connectionStringProvider = connectionStringProvider;
         this.checkpointStorageConnectionString = checkpointConnectionString;

--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/factory/DefaultEventHubClientFactory.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/factory/DefaultEventHubClientFactory.java
@@ -67,11 +67,7 @@ public class DefaultEventHubClientFactory implements EventHubClientFactory, Disp
         String checkpointConnectionString,
         String checkpointStorageContainer
     ) {
-        Assert.hasText(checkpointConnectionString, "checkpointConnectionString can't be null or empty");
-        this.connectionStringProvider = connectionStringProvider;
-        this.checkpointStorageConnectionString = checkpointConnectionString;
-        this.checkpointStorageContainer = checkpointStorageContainer;
-        this.retryOptions = new AmqpRetryOptions();
+        this(connectionStringProvider, checkpointConnectionString, checkpointStorageContainer, null);
     }
 
     public DefaultEventHubClientFactory(


### PR DESCRIPTION
## Description
Adds amqp retry options to the configuration parameters. More information see: 

https://github.com/microsoft/spring-cloud-azure/issues/709

## Todos
- [x] Tests
- [x] Documentation

[//]: # (## Steps to Test)

Add configuration under spring.cloud.azure.eventhub

