### PR TITLE
App Configuration Bug Fixes

### DIFF
--- a/spring-cloud-azure-appconfiguration-config-web/src/main/java/com/microsoft/azure/spring/cloud/config/web/AppConfigurationWebAutoConfiguration.java
+++ b/spring-cloud-azure-appconfiguration-config-web/src/main/java/com/microsoft/azure/spring/cloud/config/web/AppConfigurationWebAutoConfiguration.java
@@ -5,6 +5,7 @@
  */
 package com.microsoft.azure.spring.cloud.config.web;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.endpoint.RefreshEndpoint;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import com.microsoft.azure.spring.cloud.config.AppConfigurationRefresh;
 
 @Configuration
+@ConditionalOnBean(AppConfigurationRefresh.class)
 public class AppConfigurationWebAutoConfiguration {
 
     @Configuration

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
@@ -58,7 +58,7 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
     private ClientStore clients;
 
     private KeyVaultCredentialProvider keyVaultCredentialProvider;
-    
+
     private SecretClientBuilderSetup keyVaultClientProvider;
 
     private static Boolean startup = true;
@@ -238,10 +238,13 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
             ConfigurationSetting featureRevision = clients.getRevison(settingSelector,
                     store.getEndpoint());
 
+            String prefix = "_" + context;
+
             if (configurationRevision != null) {
-                StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX, configurationRevision);
+                StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX + prefix, configurationRevision);
             } else {
-                StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX, new ConfigurationSetting());
+                StateHolder.setEtagState(store.getEndpoint() + CONFIGURATION_SUFFIX + prefix,
+                        new ConfigurationSetting());
             }
 
             if (featureRevision != null) {

--- a/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
+++ b/spring-cloud-azure-appconfiguration-config/src/main/java/com/microsoft/azure/spring/cloud/config/AppConfigurationPropertySourceLocator.java
@@ -214,8 +214,8 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
         List<AppConfigurationPropertySource> sourceList = new ArrayList<>();
 
         try {
+            putStoreContext(store.getEndpoint(), context, storeContextsMap);
             for (String label : store.getLabels()) {
-                putStoreContext(store.getEndpoint(), context, storeContextsMap);
                 AppConfigurationPropertySource propertySource = new AppConfigurationPropertySource(context, store,
                         label, properties, clients, appProperties, keyVaultCredentialProvider, keyVaultClientProvider);
 
@@ -227,7 +227,7 @@ public class AppConfigurationPropertySourceLocator implements PropertySourceLoca
             }
 
             // Setting new ETag values for Watch
-            String watchedKeyNames = clients.watchedKeyNames(store, storeContextsMap);
+            String watchedKeyNames = clients.watchedKeyNames(store, context);
             SettingSelector settingSelector = new SettingSelector().setKeyFilter(watchedKeyNames).setLabelFilter("*");
 
             ConfigurationSetting configurationRevision = clients.getRevison(settingSelector,

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefreshTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/AppConfigurationRefreshTest.java
@@ -60,7 +60,9 @@ public class AppConfigurationRefreshTest {
     @Mock
     private ClientStore clientStoreMock;
 
-    private static final String WATCHED_KEYS = "/application/*";
+    private static final String WATCHED_KEY = "/application/*";
+    
+    private List<String> watchedKeys = new ArrayList<String>();
 
     @Before
     public void setup() {
@@ -69,7 +71,10 @@ public class AppConfigurationRefreshTest {
         ConfigStore store = new ConfigStore();
         store.setEndpoint(TEST_STORE_NAME);
         store.setConnectionString(TEST_CONN_STRING);
-        store.setWatchedKey(WATCHED_KEYS);
+        store.setWatchedKey(WATCHED_KEY);
+        
+        watchedKeys = new ArrayList<String>();
+        watchedKeys.add(WATCHED_KEY);
 
         properties = new AppConfigurationProperties();
         properties.setStores(Arrays.asList(store));
@@ -88,7 +93,7 @@ public class AppConfigurationRefreshTest {
         item.setKey("fake-etag/application/test.key");
         item.setETag("fake-etag");
 
-        when(clientStoreMock.watchedKeyNames(Mockito.any(), Mockito.any())).thenReturn(WATCHED_KEYS);
+        when(clientStoreMock.watchedKeyNames(Mockito.any(), Mockito.anyMap())).thenReturn(watchedKeys);
 
         configRefresh = new AppConfigurationRefresh(properties, contextsMap, clientStoreMock);
         StateHolder.setLoadState(TEST_STORE_NAME, true);
@@ -180,7 +185,7 @@ public class AppConfigurationRefreshTest {
         ConfigStore store = new ConfigStore();
         store.setEndpoint(TEST_STORE_NAME + "_LOST");
         store.setConnectionString(TEST_CONN_STRING);
-        store.setWatchedKey(WATCHED_KEYS);
+        store.setWatchedKey(WATCHED_KEY);
         
         AppConfigurationProperties propertiesLost = new AppConfigurationProperties();
         propertiesLost.setStores(Arrays.asList(store));
@@ -202,7 +207,7 @@ public class AppConfigurationRefreshTest {
         ConfigStore store = new ConfigStore();
         store.setEndpoint(TEST_STORE_NAME + "_LOST");
         store.setConnectionString(TEST_CONN_STRING);
-        store.setWatchedKey(WATCHED_KEYS);
+        store.setWatchedKey(WATCHED_KEY);
         
         AppConfigurationProperties propertiesLost = new AppConfigurationProperties();
         propertiesLost.setStores(Arrays.asList(store));

--- a/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/stores/ClientStoreTest.java
+++ b/spring-cloud-azure-appconfiguration-config/src/test/java/com/microsoft/azure/spring/cloud/config/stores/ClientStoreTest.java
@@ -191,7 +191,7 @@ public class ClientStoreTest {
         
         storeContextsMap.put(TEST_ENDPOINT, contexts);
         
-        assertEquals("/application/*", clientStore.watchedKeyNames(store, storeContextsMap));
+        assertEquals("/application/*", clientStore.watchedKeyNames(store, "/application/"));
     }
 
     private PagedFlux<ConfigurationSetting> getConfigurationPagedFlux(int noOfPages) throws MalformedURLException {

--- a/spring-cloud-azure-feature-management/src/main/java/com/microsoft/azure/spring/cloud/feature/manager/FeatureManager.java
+++ b/spring-cloud-azure-feature-management/src/main/java/com/microsoft/azure/spring/cloud/feature/manager/FeatureManager.java
@@ -145,6 +145,10 @@ public class FeatureManager extends HashMap<String, Object> {
             return;
         }
         
+        // Need to reset or switch between on/off to conditional doesn't work
+        featureManagement = new HashMap<String, Feature>();
+        onOff = new HashMap<String, Boolean>();
+        
         if (m.size() == 1 && m.containsKey("featureManagement")) {
             m = (Map<? extends String, ? extends Object>) m.get("featureManagement");
         }

--- a/spring-cloud-azure-feature-management/src/main/java/com/microsoft/azure/spring/cloud/feature/manager/FeatureManager.java
+++ b/spring-cloud-azure-feature-management/src/main/java/com/microsoft/azure/spring/cloud/feature/manager/FeatureManager.java
@@ -145,6 +145,10 @@ public class FeatureManager extends HashMap<String, Object> {
             return;
         }
         
+        if (m.size() == 1 && m.containsKey("featureManagement")) {
+            m = (Map<? extends String, ? extends Object>) m.get("featureManagement");
+        }
+        
         for (String key : m.keySet()) {
             addToFeatures(m, key, "");
         }


### PR DESCRIPTION
- Fixes Refresh not being disabled when provider is disabled. https://github.com/Azure/AppConfiguration/issues/332
- Fixed an issue where duplicate watch keys were added to watch checks, the number of duplicates were based off the number labels and profiles used. This might fix https://github.com/microsoft/spring-cloud-azure/issues/675
- Fixed feature management name issue.
- Fixed issue where switching from an on/off feature flag to conditional didn't work.