### PR TITLE
Add messge header nativeHeaders serialization

### DIFF
--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverter.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverter.java
@@ -42,10 +42,11 @@ public class EventHubMessageConverter extends AbstractAzureMessageConverter<Even
     protected void setCustomHeaders(MessageHeaders headers, EventData azureMessage) {
         super.setCustomHeaders(headers, azureMessage);
         headers.forEach((key, value) -> {
-            azureMessage.getProperties().put(key, value.toString());
             if (key.equals(NativeMessageHeaderAccessor.NATIVE_HEADERS)
                     && value instanceof LinkedMultiValueMap) {
                 azureMessage.getProperties().put(key, toJson(value));
+            } else {
+                azureMessage.getProperties().put(key, value.toString());
             }
         });
     }

--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverter.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverter.java
@@ -10,6 +10,8 @@ import com.azure.messaging.eventhubs.EventData;
 import com.microsoft.azure.spring.integration.core.converter.AbstractAzureMessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.util.LinkedMultiValueMap;
 
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -39,12 +41,26 @@ public class EventHubMessageConverter extends AbstractAzureMessageConverter<Even
     @Override
     protected void setCustomHeaders(MessageHeaders headers, EventData azureMessage) {
         super.setCustomHeaders(headers, azureMessage);
-        headers.forEach((key, value) -> azureMessage.getProperties().put(key, value.toString()));
+        headers.forEach((key, value) -> {
+            azureMessage.getProperties().put(key, value.toString());
+            if (key.equals(NativeMessageHeaderAccessor.NATIVE_HEADERS)) {
+                if (value instanceof LinkedMultiValueMap) {
+                    azureMessage.getProperties().put(key, toJson(value));
+                }
+            }
+        });
     }
 
     @Override
     protected Map<String, Object> buildCustomHeaders(EventData azureMessage) {
         Map<String, Object> headers = super.buildCustomHeaders(azureMessage);
+        Map<String, Object> properties = azureMessage.getProperties();
+        if (properties.containsKey(NativeMessageHeaderAccessor.NATIVE_HEADERS)
+                && isValidJson(properties.get(NativeMessageHeaderAccessor.NATIVE_HEADERS))) {
+            String nativeHeader = (String) properties.remove(NativeMessageHeaderAccessor.NATIVE_HEADERS);
+            properties.put(NativeMessageHeaderAccessor.NATIVE_HEADERS,
+                    readValue(nativeHeader, LinkedMultiValueMap.class));
+        }
         headers.putAll(azureMessage.getProperties());
         return headers;
     }

--- a/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverter.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/main/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverter.java
@@ -43,10 +43,9 @@ public class EventHubMessageConverter extends AbstractAzureMessageConverter<Even
         super.setCustomHeaders(headers, azureMessage);
         headers.forEach((key, value) -> {
             azureMessage.getProperties().put(key, value.toString());
-            if (key.equals(NativeMessageHeaderAccessor.NATIVE_HEADERS)) {
-                if (value instanceof LinkedMultiValueMap) {
-                    azureMessage.getProperties().put(key, toJson(value));
-                }
+            if (key.equals(NativeMessageHeaderAccessor.NATIVE_HEADERS)
+                    && value instanceof LinkedMultiValueMap) {
+                azureMessage.getProperties().put(key, toJson(value));
             }
         });
     }

--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
@@ -48,7 +48,7 @@ public class EventHubMessageConverterTest extends AzureMessageConverterTest<Even
         return EventData.class;
     }
 
-    static class MyEventHubMessageConverter extends EventHubMessageConverter {
+    private static class MyEventHubMessageConverter extends EventHubMessageConverter {
 
         public void setCustomHeaders(MessageHeaders headers, EventData azureMessage) {
             super.setCustomHeaders(headers, azureMessage);

--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
@@ -7,10 +7,31 @@
 package com.microsoft.azure.spring.integration.eventhub.converter;
 
 import com.azure.messaging.eventhubs.EventData;
+import com.microsoft.azure.spring.integration.core.AzureHeaders;
 import com.microsoft.azure.spring.integration.core.converter.AzureMessageConverter;
 import com.microsoft.azure.spring.integration.test.support.AzureMessageConverterTest;
+import org.junit.Test;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.util.LinkedMultiValueMap;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class EventHubMessageConverterTest extends AzureMessageConverterTest<EventData> {
+
+    private final static String EVENT_DATA = "event-hub-test-string";
+    private final static int PARTITION_ID = 1;
+    private final static String NATIVE_HEADERS_SPAN_ID_KEY = "spanId";
+    private final static List<String> NATIVE_HEADERS_SPAN_ID_VALUE = Arrays.asList("spanId-1", "spanId-2");
+    private final static String NATIVE_HEADERS_SPAN_TRACE_ID_KEY = "spanTraceId";
+    private final static List<String> NATIVE_HEADERS_SPAN_TRACE_ID_VALUE = Arrays
+            .asList("spanTraceId-1", "spanTraceId-2");
 
     @Override
     protected EventData getInstance() {
@@ -25,5 +46,68 @@ public class EventHubMessageConverterTest extends AzureMessageConverterTest<Even
     @Override
     protected Class<EventData> getTargetClass() {
         return EventData.class;
+    }
+
+    static class MyEventHubMessageConverter extends EventHubMessageConverter {
+
+        public void setCustomHeaders(MessageHeaders headers, EventData azureMessage) {
+            super.setCustomHeaders(headers, azureMessage);
+        }
+
+        public Map<String, Object> buildCustomHeaders(EventData azureMessage) {
+            return super.buildCustomHeaders(azureMessage);
+        }
+    }
+
+    @Test
+    public void testSetCustomHeadersWithCommon() {
+        EventData eventData = new EventData(EVENT_DATA);
+        Map<String, Object> headerMap = new HashMap<>();
+        headerMap.put(AzureHeaders.RAW_PARTITION_ID, PARTITION_ID);
+        MessageHeaders headers = new MessageHeaders(headerMap);
+
+        MyEventHubMessageConverter convert = new MyEventHubMessageConverter();
+        convert.setCustomHeaders(headers, eventData);
+        assertEquals(Integer.parseInt(String.valueOf(eventData.getProperties().get(AzureHeaders.RAW_PARTITION_ID))), PARTITION_ID);
+        assertEquals(eventData.getBodyAsString(), EVENT_DATA);
+    }
+
+    @Test
+    public void testSetCustomHeadersWithNativesHeader() {
+        EventData eventData = new EventData(EVENT_DATA);
+        Map<String, Object> headerMap = new HashMap<>();
+        LinkedMultiValueMap<String, String> linkedMultiValueMap = new LinkedMultiValueMap<>();
+        linkedMultiValueMap.put(NATIVE_HEADERS_SPAN_ID_KEY, NATIVE_HEADERS_SPAN_ID_VALUE);
+        linkedMultiValueMap.put(NATIVE_HEADERS_SPAN_TRACE_ID_KEY, NATIVE_HEADERS_SPAN_TRACE_ID_VALUE);
+        headerMap.put(NativeMessageHeaderAccessor.NATIVE_HEADERS, linkedMultiValueMap);
+        MessageHeaders headers = new MessageHeaders(headerMap);
+
+        MyEventHubMessageConverter convert = new MyEventHubMessageConverter();
+        convert.setCustomHeaders(headers, eventData);
+        assertSame(eventData.getProperties().get(NativeMessageHeaderAccessor.NATIVE_HEADERS).getClass(),
+                String.class);
+    }
+
+    @Test
+    public void testBuildCustomHeadersWithCommon() {
+        EventData eventData = new EventData(EVENT_DATA);
+        eventData.getProperties().put(AzureHeaders.RAW_PARTITION_ID, PARTITION_ID);
+        MyEventHubMessageConverter convert = new MyEventHubMessageConverter();
+        Map<String, Object> headerHeadersMap = convert.buildCustomHeaders(eventData);
+        assertEquals(headerHeadersMap.get(AzureHeaders.RAW_PARTITION_ID), PARTITION_ID);
+        assertEquals(eventData.getBodyAsString(), EVENT_DATA);
+    }
+
+    @Test
+    public void testBuildCustomHeadersWithNativeHeaders() {
+        EventData eventData = new EventData(EVENT_DATA);
+        String nativeHeadersString = "{\"spanId\":[\"spanId-1\", \"spanId-2\"]," +
+                "\"spanTraceId\":[\"spanTraceId-1\", \"spanTraceId-2\"]}";
+        eventData.getProperties().put(NativeMessageHeaderAccessor.NATIVE_HEADERS, nativeHeadersString);
+
+        MyEventHubMessageConverter convert = new MyEventHubMessageConverter();
+        Map<String, Object> headerHeadersMap = convert.buildCustomHeaders(eventData);
+        assertSame(headerHeadersMap.get(NativeMessageHeaderAccessor.NATIVE_HEADERS).getClass(),
+                LinkedMultiValueMap.class);
     }
 }

--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
@@ -25,12 +25,12 @@ import static org.junit.Assert.assertSame;
 
 public class EventHubMessageConverterTest extends AzureMessageConverterTest<EventData> {
 
-    private final static String EVENT_DATA = "event-hub-test-string";
-    private final static int PARTITION_ID = 1;
-    private final static String NATIVE_HEADERS_SPAN_ID_KEY = "spanId";
-    private final static List<String> NATIVE_HEADERS_SPAN_ID_VALUE = Arrays.asList("spanId-1", "spanId-2");
-    private final static String NATIVE_HEADERS_SPAN_TRACE_ID_KEY = "spanTraceId";
-    private final static List<String> NATIVE_HEADERS_SPAN_TRACE_ID_VALUE = Arrays
+    private static final String EVENT_DATA = "event-hub-test-string";
+    private static final int PARTITION_ID = 1;
+    private static final String NATIVE_HEADERS_SPAN_ID_KEY = "spanId";
+    private static final List<String> NATIVE_HEADERS_SPAN_ID_VALUE = Arrays.asList("spanId-1", "spanId-2");
+    private static final String NATIVE_HEADERS_SPAN_TRACE_ID_KEY = "spanTraceId";
+    private static final List<String> NATIVE_HEADERS_SPAN_TRACE_ID_VALUE = Arrays
             .asList("spanTraceId-1", "spanTraceId-2");
 
     @Override

--- a/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
+++ b/spring-integration-azure/spring-integration-eventhubs/src/test/java/com/microsoft/azure/spring/integration/eventhub/converter/EventHubMessageConverterTest.java
@@ -68,7 +68,8 @@ public class EventHubMessageConverterTest extends AzureMessageConverterTest<Even
 
         MyEventHubMessageConverter convert = new MyEventHubMessageConverter();
         convert.setCustomHeaders(headers, eventData);
-        assertEquals(Integer.parseInt(String.valueOf(eventData.getProperties().get(AzureHeaders.RAW_PARTITION_ID))), PARTITION_ID);
+        assertEquals(Integer.parseInt(String.valueOf(eventData.getProperties()
+                .get(AzureHeaders.RAW_PARTITION_ID))), PARTITION_ID);
         assertEquals(eventData.getBodyAsString(), EVENT_DATA);
     }
 


### PR DESCRIPTION
## Description
Serialize nativeHeaders value to json before sending and deserialize the header to the correct value when receiving message when receiving.
Bug fix https://github.com/microsoft/spring-cloud-azure/issues/592

[//]: # (## Related PRs)
[//]: # (List related PRs against other branches:)

[//]: # (branch | PR)
[//]: # (------ | ------)
[//]: # (other_pr_production | [link])
[//]: # (other_pr_master | [link])

## Todos
- [ ] Tests
- [ ] Documentation

[//]: # (## Steps to Test)
[//]: # (Steps to test code change)
