### PR TITLE
Use "[%autowidth.stretch]" for table in getting-help.adoc.

### DIFF
--- a/docs/src/main/asciidoc/getting-help.adoc
+++ b/docs/src/main/asciidoc/getting-help.adoc
@@ -4,6 +4,7 @@
 If you have any questions about this doc, please ask by creating GitHub issue. And PR is welcome.
 
 .GitHub repos
+[%autowidth.stretch]
 [cols="<30,<70", options="header"]
 |===
 |GitHub repo | Description


### PR DESCRIPTION
As title. 

![image](https://user-images.githubusercontent.com/13167207/143154255-f35cc1e8-5204-4ed1-a580-bf68d9749d45.png)


Refs: https://docs.asciidoctor.org/asciidoc/latest/tables/width/#autowidth