### PR TITLE
Fix/version not right

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -13,7 +13,6 @@
 	<name>spring-cloud-azure-build-docs</name>
 	<packaging>jar</packaging>
 	<description>Spring Cloud Azure Build Docs</description>
-	<version>4.0.0-beta.3</version>
 
 	<properties>
 		<docs.main>spring-cloud-azure</docs.main>

--- a/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
+++ b/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
@@ -67,13 +67,15 @@ dependencyManagement of your project to benefit from the dependency management.
         <dependency>
             <groupId>com.azure.spring</groupId>
             <artifactId>spring-cloud-azure-dependencies</artifactId>
-            <version>4.0.0-beta.2</version>
+            <version>version</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
     </dependencies>
 </dependencyManagement>
 ----
+
+The version for spring-cloud-azure-dependencies is {project-version}.
 
 === Artifact changes: renamed / added / deleted
 

--- a/docs/src/main/asciidoc/appendix.adoc
+++ b/docs/src/main/asciidoc/appendix.adoc
@@ -1,10 +1,12 @@
 
-include::_attributes.adoc[]
+[appendix]
+== Configuration Properties
+
+include::_configprops.adoc[]
 
 [appendix]
-include::_configprops.adoc[]
-[appendix]
 include::_migration-guide-for-4.0.adoc[]
+
 [appendix]
 include::_known-issues.adoc[]
 

--- a/docs/src/main/asciidoc/getting-help.adoc
+++ b/docs/src/main/asciidoc/getting-help.adoc
@@ -9,10 +9,10 @@ If you have any questions about this doc, please ask by creating GitHub issue. A
 |===
 |GitHub repositories | Description
 
-|https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/spring[Azure/azure-sdk-for-java]
+|https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure-dependencies_{project-version}/sdk/spring[Azure/azure-sdk-for-java]
 |This repository used to hold the source code.
 
-|https://github.com/microsoft/spring-cloud-azure/tree/docs/docs/src/main/asciidoc[microsoft/spring-cloud-azure]
+|https://github.com/microsoft/spring-cloud-azure/tree/{project-version}/docs/src/main/asciidoc[microsoft/spring-cloud-azure]
 |This repository used to hold the document which is displaying in current page.
 
 |===

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -11,13 +11,15 @@
     <dependency>
       <groupId>com.azure.spring</groupId>
       <artifactId>spring-cloud-azure-dependencies</artifactId>
-      <version>4.0.0-beta.2</version>
+      <version>version</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
   </dependencies>
 </dependencyManagement>
 ----
+
+The version for spring-cloud-azure-dependencies is {project-version}.
 
 [#starter-dependencies]
 ==== Starter Dependencies

--- a/docs/src/main/asciidoc/resource-handling.adoc
+++ b/docs/src/main/asciidoc/resource-handling.adoc
@@ -199,9 +199,10 @@ try (OutputStream fileos = ((WritableResource) this.storageFileResource).getOutp
 
 ----
 
-#### Multipart upload
+==== Multipart upload
+
 Files larger than 4 MiB will be uploaded to Azure Storage in parallel.
 
 === Samples
 
-Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0.0-beta.2/storage/spring-cloud-azure-starter-storage-blob/storage-blob-sample[storage-blob-sample] and link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0.0-beta.2/storage/spring-cloud-azure-starter-storage-file-share/storage-file-sample[storage-file-sample] for more details.
+Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_{project-version}/storage/spring-cloud-azure-starter-storage-blob/storage-blob-sample[storage-blob-sample] and link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_{project-version}/storage/spring-cloud-azure-starter-storage-file-share/storage-file-sample[storage-file-sample] for more details.

--- a/docs/src/main/asciidoc/secret-management.adoc
+++ b/docs/src/main/asciidoc/secret-management.adoc
@@ -171,5 +171,5 @@ spring.cloud.azure.keyvault.secret.property-sources[].case-sensitive=true
 
 === Samples
 
-Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0.0-beta.3/keyvault/spring-cloud-azure-starter-keyvault-secrets[spring-cloud-azure-starter-keyvault-secrets samples] for more details.
+Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_{project-version}/keyvault/spring-cloud-azure-starter-keyvault-secrets[spring-cloud-azure-starter-keyvault-secrets samples] for more details.
 

--- a/docs/src/main/asciidoc/spring-data-support.adoc
+++ b/docs/src/main/asciidoc/spring-data-support.adoc
@@ -261,8 +261,8 @@ Autowired UserRepository interface, then can do save, delete and find operations
 
 === Samples
 
-Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0.0-beta.2/cosmos[azure-spring-boot-samples] for more details.
+Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_{project-version}/cosmos[azure-spring-boot-samples] for more details.
 
 
-Besides using this Azure Cosmos DB Spring Boot Starter, you can directly use Spring Data for Azure Cosmos DB package for more complex scenarios. Please refer to link:https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-spring-data-cosmos[Spring Data for Azure Cosmos DB] for more details.
+Besides, using this Azure Cosmos DB Spring Boot Starter, you can directly use Spring Data for Azure Cosmos DB package for more complex scenarios. Please refer to link:https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure-dependencies_{project-version}/sdk/cosmos/azure-spring-data-cosmos[Spring Data for Azure Cosmos DB] for more details.
 

--- a/docs/src/main/asciidoc/spring-security-support.adoc
+++ b/docs/src/main/asciidoc/spring-security-support.adoc
@@ -223,7 +223,7 @@ image:https://user-images.githubusercontent.com/13167207/142617785-b4ca1afc-79f6
 </dependencies>
 ----
 
-* Step 3: Add properties in application.yml. These values should be got in https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/spring/azure-spring-boot-starter-active-directory#prerequisites[prerequisite].
+* Step 3: Add properties in application.yml.
 
 [source,yaml]
 ----
@@ -248,7 +248,7 @@ The `AADWebSecurityConfigurerAdapter` contains necessary web security configurat
 
 image:https://user-images.githubusercontent.com/13167207/142617853-0526205f-fdef-47f9-ac01-77963f8c34be.png[web-application-visiting-resource-servers.png]
 
-* Step 1: Make sure `redirect URI` has been set, just like https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/spring/azure-spring-boot-starter-active-directory#accessing-a-web-application[Accessing a web application].
+* Step 1: Make sure `redirect URI` has been set.
 
 * Step 2: Add the following dependencies in you pom.xml.
 


### PR DESCRIPTION
1. Use variable instead of plain text about version in adoc files. 
2. Delete unnecessary "<version>" in pom. Extend from parent instead.
3. Change markdown style title to adoc style.
4. Fix error content about Azure AD related links.
5. Fix the problem: Configuration properties not displayed in appendix.