### PR TITLE
Update eh binder reference doc

### DIFF
--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -1,3 +1,4 @@
+[#configuration]
 == Configuration
 
 Most of Azure Service SDKs could be divided into two categories by transport type, HTTP-based and AMQP-based. There are properties that are common to all SDKs such as authentication principals and Azure environment settings. Or common to HTTP-based clients, such as logging level to log http requests and responses. In Spring Cloud Azure 4.0 we added five common categories of configuration properties, which could be specified to each Azure service.

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -13,31 +13,33 @@ Current binder implementations include:
 === Spring Cloud Stream Binder for Azure Event Hubs
 
 ==== Key concepts
-The Spring Cloud Stream Binder for Azure Event Hub provides the binding implementation for the Spring Cloud Stream.
-This implementation uses Spring Integration Event Hub Channel Adapters at its foundation. From design's perspective,
-Event Hub is similar as Kafka. Also, Event Hub could be accessed via Kafka API. If your project has tight dependency
-on Kafka API, you can try link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0/eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka[Event Hub with Kafka API Sample]
+The Spring Cloud Stream Binder for Azure Event Hubs provides the binding implementation for the Spring Cloud Stream framework.
+This implementation uses Spring Integration Event Hubs Channel Adapters at its foundation. From design's perspective,
+Event Hubs is similar as Kafka. Also, Event Hubs could be accessed via Kafka API. If your project has tight dependency
+on Kafka API, you can try link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0/eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka[Events Hub with Kafka API Sample]
 
 ===== Consumer Group
 
-Event Hub provides similar support of consumer group as Apache Kafka, but with slight different logic. While Kafka
-stores all committed offsets in the broker, you have to store offsets of event hub messages
-being processed manually. Event Hub SDK provide the function to store such offsets inside Azure Storage Account. So
+Event Hubs provides similar support of consumer group as Apache Kafka, but with slight different logic. While Kafka
+stores all committed offsets in the broker, you have to store offsets of Event Hubs messages
+being processed manually. Event Hubs SDK provide the function to store such offsets inside Azure Storage Account. So
 that's why you have to fill `spring.cloud.eventhubs.processor.checkpoint-store.*`.
 
 ===== Partitioning Support
 
-Event Hubs provides a similar concept of physical partition as Kafka. But unlike Kafka's auto re-balancing between consumers and partitions, Event Hub provides a kind of preemptive mode. The storage account acts as a lease to determine which partition is owned by which consumer. When a new consumer starts, it will try to steal some partitions
+Event Hubs provides a similar concept of physical partition as Kafka. But unlike Kafka's auto re-balancing between consumers and partitions, Event Hubs provides a kind of preemptive mode. The storage account acts as a lease to determine which partition is owned by which consumer. When a new consumer starts, it will try to steal some partitions
 from most heavy-loaded consumers to achieve the workload balancing.
+
+To specify the load balancing strategy, properties of `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.load-balancing.*` are providec. See <<eventhubs-consumer-properties, the consumer properties>> for more details.
 
 ===== Batch Consumer Support
 Azure Event Hubs Spring Cloud Stream Binder supports link:https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#_batch_consumers[Spring Cloud Stream Batch Consumer feature].
 
-To work with the batch-consumer mode, the property of `spring.cloud.stream.bindings.<binding-name>.consumer.batch-mode` should be set as `true`. When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of **com.azure.spring.integration.core.AzureHeaders#RAW_PARTITION_ID** and **com.azure.spring.integration.core.AzureHeaders.CHECKPOINTER**, they are presented as a single value for the entire batch of events shares the same one.
+To work with the batch-consumer mode, the property of `spring.cloud.stream.bindings.<binding-name>.consumer.batch-mode` should be set as `true`. When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of partition id, checkpointer and last enqueued properties, they are presented as a single value for the entire batch of events shares the same one.
 
 NOTE: the checkpoint header only exists when **MANUAL** checkpoint mode is used.
 
-Checkpointing of batch consumer supports two modes: BATCH and MANUAL. BATCH mode is an auto checkpointing mode to checkpoint the entire batch of events together once they are received by the binder. MANUAL mode is to checkpoint the events by users. When used, the
+Checkpointing of batch consumer supports two modes: `BATCH` and `MANUAL`. `BATCH` mode is an auto checkpointing mode to checkpoint the entire batch of events together once they are received by the binder. `MANUAL` mode is to checkpoint the events by users. When used, the
 **com.azure.spring.messaging.checkpoint.Checkpointer** will be passes into the message header, and users could use it to do checkpointing.
 
 The batch size can be specified by properties of `max-size` and `max-wait-time` with prefix as `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.batch.`, where `max-size` is a necessary property while `max-wait-time` is optional. See <<eventhubs-consumer-properties, the consumer properties>> for more details.
@@ -54,13 +56,13 @@ The batch size can be specified by properties of `max-size` and `max-wait-time` 
 
 ==== Configuration
 
-NOTE: If you choose to use a security principal to authenticate and authorize with Azure Active Directory for accessing an Azure resource, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
-
 The binder provides the following 3 parts of configuration options:
 
 [#eventhubs-connection-configration]
 ===== Connection Configuration Properties
 These properties are exposed via `com.azure.spring.cloud.autoconfigure.eventhubs.properties.AzureEventHubsProperties`.
+
+NOTE: If you choose to use a security principal to authenticate and authorize with Azure Active Directory for accessing an Azure resource, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
 
 .Connection configurable properties of spring-cloud-azure-stream-binder-eventhubs
 [cols="<,<,<", options="header"]
@@ -83,19 +85,9 @@ These properties are exposed via `com.azure.spring.cloud.autoconfigure.eventhubs
 | String
 | Domain name of an Azure Event Hubs Namespace value.
 
-|*spring.cloud.azure.eventhubs*.event-hub-name
-| String
-| Name of an Event Hub entity.
-
-|*spring.cloud.azure.eventhubs*.
-custom-endpoint-address
+|*spring.cloud.azure.eventhubs*.custom-endpoint-address
 | String
 | Custom Endpoint address.
-
-|*spring.cloud.azure.eventhubs*.
-is-shared-connection
-| Boolean
-| Whether to use the same connection for different Event Hub producer / consumer client.
 
 |===
 
@@ -191,7 +183,7 @@ Configurations, Producer PropertiesProducer Properties, and Advanced Producer Co
 |===
 
 ====== Advanced Consumer Configuration
-The above <<eventhubs-connection-configration, connection>>, <<Checkpoint Configuration Properties, checkpoint>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix *spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.*.
+The above <<eventhubs-connection-configration, connection>>, <<Checkpoint Configuration Properties, checkpoint>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.`.
 
 ====== Producer Properties
 
@@ -210,7 +202,7 @@ The above <<eventhubs-connection-configration, connection>>, <<Checkpoint Config
 |===
 
 ====== Advanced Producer Configuration
-The above <<eventhubs-connection-configration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix *spring.cloud.stream.eventhubs.bindings.<binding-name>.producer.*.
+The above <<eventhubs-connection-configration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.producer.`.
 
 ==== Basic Usage
 ===== Sending and Receiving messages from/to Event Hubs
@@ -477,7 +469,47 @@ public void producerError(Message<?> message) {
 ----
 
 ===== Event Hubs message headers
-See the link:spring-integration-support.html#_event_hubs_message_headers[Event Hubs message headers] for more details.
+See the link:spring-integration-support.html#_event_hubs_message_headers[Event Hubs message headers] for the basic message headers supported.
+
+When the batch-consumer mode is enabled, the specific headers of batched messages are listed as below, which contains a list of values from each single Event Hubs event.
+
+.Mapping between Batch Event Hubs Properties and Spring Headers
+[cols="<,<,<,<", options="header"]
+|===
+|Event Hubs Event Properties | Spring Batch Message Header Constants | Type | Description
+
+|Enqueued time
+|com.azure.spring.eventhubs.support.EventHubsHeaders#BATCH_CONVERTED_ENQUEUED_TIME
+|List of Instant
+|List of the instant, in UTC, of when each event was enqueued in the Event Hub partition.
+
+|Offset
+|com.azure.spring.eventhubs.support.EventHubsHeaders#BATCH_CONVERTED_OFFSET
+|List of Long
+|List of the offset of each event when it was received from the associated Event Hub partition.
+
+|Partition key
+|com.azure.spring.messaging.AzureHeaders#BATCH_CONVERTED_PARTITION_KEY
+|List of String
+|List of the partition hashing key if it was set when originally publishing each event.
+
+|Sequence number
+|com.azure.spring.eventhubs.support.EventHubsHeaders#BATCH_CONVERTED_SEQUENCE_NUMBER
+|List of Long
+|List of the sequence number assigned to each event when it was enqueued in the associated Event Hub partition.
+
+|System properties
+|com.azure.spring.eventhubs.support.EventHubsHeaders#BATCH_CONVERTED_SYSTEM_PROPERTIES
+|List of Map
+|List of the system properties of each event.
+
+|Application properties
+|com.azure.spring.eventhubs.support.EventHubsHeaders#BATCH_CONVERTED_APPLICATION_PROPERTIES
+|List of Map
+|List of the applocation properties of each event, where all customzied message headers or event properties are placed.
+|===
+
+NOTE: When publish messages, all the above batch headers if exist will be removed from the messages to send.
 
 ==== Samples
 

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -31,7 +31,7 @@ Event Hubs provides a similar concept of physical partition as Kafka. But unlike
 from most heavy-loaded consumers to achieve the workload balancing.
 
 ===== Batch Consumer Support
-Azure Event Hubs Spring Cloud Stream Binder supports link:https://docs.spring.io/spring-cloud-stream/docs/3.1.4/reference/html/spring-cloud-stream.html#_batch_consumers[Spring Cloud Stream Batch Consumer feature].
+Azure Event Hubs Spring Cloud Stream Binder supports link:https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#_batch_consumers[Spring Cloud Stream Batch Consumer feature].
 
 To work with the batch-consumer mode, the property of `spring.cloud.stream.bindings.<binding-name>.consumer.batch-mode` should be set as `true`. When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of **com.azure.spring.integration.core.AzureHeaders#RAW_PARTITION_ID** and **com.azure.spring.integration.core.AzureHeaders.CHECKPOINTER**, they are presented as a single value for the entire batch of events shares the same one.
 
@@ -57,8 +57,6 @@ The batch size can be specified by properties of `max-size` and `max-wait-time` 
 NOTE: If you choose to use a security principal to authenticate and authorize with Azure Active Directory for accessing an Azure resource, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
 
 The binder provides the following 3 parts of configuration options:
-
-NOTE: From version 4.0.0, when the property of **spring.cloud.azure.eventhubs.processor.checkpoint-store.create-container-if-not-exists** is not enabled manually, no Storage container will be created automatically with the name from **spring.cloud.azure.eventhubs.event-hub-name**.
 
 [#eventhubs-connection-configration]
 ===== Connection Configuration Properties
@@ -101,11 +99,13 @@ is-shared-connection
 
 |===
 
-TIP: Common Azure Service SDK configuration options are configurable for the Spring Cloud Stream Event Hubs binder as well. The supported configuration options are introduced in link:configuration.adoc[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.`.
+TIP: Common Azure Service SDK configuration options are configurable for the Spring Cloud Stream Event Hubs binder as well. The supported configuration options are introduced in link:configuration.html[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.`.
 
 ===== Checkpoint Configuration Properties
 These properties are exposed via `com.azure.spring.cloud.autoconfigure.eventhubs.properties.AzureEventHubsProperties.Processor.BlobCheckpointStore`
 for the configuration of `BlobCheckpointStore`, which is the default implementation of `CheckpointStore` to use Storage Blobs for persisting partition ownership and checkpoint information.
+
+NOTE: From version 4.0.0, when the property of **spring.cloud.azure.eventhubs.processor.checkpoint-store.create-container-if-not-exists** is not enabled manually, no Storage container will be created automatically with the name from **spring.cloud.azure.eventhubs.event-hub-name**.
 
 .Checkpointing configurable properties of spring-cloud-azure-stream-binder-eventhubs
 [cols="<,<,<", options="header"]
@@ -129,7 +129,7 @@ for the configuration of `BlobCheckpointStore`, which is the default implementat
 | Storage container name.
 |===
 
-TIP: Common Azure Service SDK configuration options are configurable for Storage Blob checkpoint store as well. The supported configuration options are introduced in link:configuration.adoc[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.processor.checkpoint-store`.
+TIP: Common Azure Service SDK configuration options are configurable for Storage Blob checkpoint store as well. The supported configuration options are introduced in link:configuration.html[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.processor.checkpoint-store`.
 
 NOTE: The default maximum connection pool size of the Storage Blob client is changed from `500` in version 3.x to `16` now, and the pending acquire queue size which is double of pool size is then `32` now. To override them, please set the property `spring.cloud.azure.eventhubs.processor.checkpoint-store.client.maximum-connection-pool-size`.
 
@@ -477,7 +477,7 @@ public void producerError(Message<?> message) {
 ----
 
 ===== Event Hubs message headers
-See the <<spring-integration-support.adoc#event-hubs-message-headers, Event Hubs message headers>> for more details.
+See the link:spring-integration-support.html#_event_hubs_message_headers[Event Hubs message headers] for more details.
 
 ==== Samples
 

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -33,14 +33,14 @@ from most heavy-loaded consumers to achieve the workload balancing.
 ===== Batch Consumer Support
 Azure Event Hubs Spring Cloud Stream Binder supports link:https://docs.spring.io/spring-cloud-stream/docs/3.1.4/reference/html/spring-cloud-stream.html#_batch_consumers[Spring Cloud Stream Batch Consumer feature].
 
-When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of **com.azure.spring.integration.core.AzureHeaders#RAW_PARTITION_ID** and **com.azure.spring.integration.core.AzureHeaders.CHECKPOINTER**, they are presented as a single value for the entire batch of events share the same one.
+To work with the batch-consumer mode, the property of `spring.cloud.stream.bindings.<binding-name>.consumer.batch-mode` should be set as `true`. When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of **com.azure.spring.integration.core.AzureHeaders#RAW_PARTITION_ID** and **com.azure.spring.integration.core.AzureHeaders.CHECKPOINTER**, they are presented as a single value for the entire batch of events shares the same one.
 
 NOTE: the checkpoint header only exists when **MANUAL** checkpoint mode is used.
 
 Checkpointing of batch consumer supports two modes: BATCH and MANUAL. BATCH mode is an auto checkpointing mode to checkpoint the entire batch of events together once they are received by the binder. MANUAL mode is to checkpoint the events by users. When used, the
-**com.azure.spring.integration.core.api.reactor.Checkpointer** will be passes into the message header, and users could use it to do checkpointing.
+**com.azure.spring.messaging.checkpoint.Checkpointer** will be passes into the message header, and users could use it to do checkpointing.
 
-The batch size can be specified by properties of `max-size` and `max-wait-time` with prefix as `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.batch.`.
+The batch size can be specified by properties of `max-size` and `max-wait-time` with prefix as `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.batch.`, where `max-size` is a necessary property while `max-wait-time` is optional. See <<eventhubs-consumer-properties, the consumer properties>> for more details.
 
 ==== Dependency Setup
 
@@ -60,11 +60,11 @@ The binder provides the following 3 parts of configuration options:
 
 NOTE: From version 4.0.0, when the property of **spring.cloud.azure.eventhubs.processor.checkpoint-store.create-container-if-not-exists** is not enabled manually, no Storage container will be created automatically with the name from **spring.cloud.azure.eventhubs.event-hub-name**.
 
-===== Azure Common Configuration Options
-Below properties can also be configured with the default Spring Cloud Azure unified properties,
-of which the prefix is changed from *spring.cloud.azure.eventhubs* to *spring.cloud.azure*.
+[#eventhubs-connection-configration]
+===== Connection Configuration Properties
+These properties are exposed via `com.azure.spring.cloud.autoconfigure.eventhubs.properties.AzureEventHubsProperties`.
 
-.Common configurable properties of spring-cloud-azure-stream-binder-eventhubs
+.Connection configurable properties of spring-cloud-azure-stream-binder-eventhubs
 [cols="<,<,<", options="header"]
 |===
 |Property | Type |Description
@@ -72,166 +72,6 @@ of which the prefix is changed from *spring.cloud.azure.eventhubs* to *spring.cl
 |*spring.cloud.azure.eventhubs*.enabled
 | boolean
 | Whether an Azure Event Hubs is enabled.
-
-|*spring.cloud.azure.eventhubs*.credential.*
-| NA
-| Properties used for getting token credential.
-
-|*spring.cloud.azure.eventhubs*.
-credential.client-id
-| String
-| Client id to use when performing service principal authentication with Azure.
-
-|*spring.cloud.azure.eventhubs*.
-credential.client-secret
-| String
-| Client secret to use when performing service principal authentication with Azure.
-
-|*spring.cloud.azure.eventhubs*.
-credential.client-certificate-path
-| String
-| Path of a PEM certificate file to use when performing service principal authentication with Azure.
-
-|*spring.cloud.azure.eventhubs*.
-credential.client-certificate-password
-| String
-| Password of the certificate file.
-
-|*spring.cloud.azure.eventhubs*.
-credential.username
-| String
-| Username to use when performing username/password authentication with Azure.
-
-|*spring.cloud.azure.eventhubs*.
-credential.password
-| String
-| Password to use when performing username/password authentication with Azure.
-
-|*spring.cloud.azure.eventhubs*.
-credential.managed-identity-client-id
-| String
-| The client id to use when using managed identity to authenticate with Azure.
-
-|*spring.cloud.azure.eventhubs*.profile.*
-| String
-| The properties related to an Azure subscription.
-
-|*spring.cloud.azure.eventhubs*.
-profile.tenant-id
-| String
-| Tenant id for Azure resources.
-
-|*spring.cloud.azure.eventhubs*.
-profile.subscription-id
-| String
-| Subscription id to use when connecting to Azure resources.
-
-|*spring.cloud.azure.eventhubs*.profile.cloud
-| AzureProfileAware.CloudType
-| The name of the Azure cloud to connect to.
-
-|*spring.cloud.azure.eventhubs*.
-profile.environment.*
-| NA
-| Properties to Azure services, such as endpoints, resource ids, etc.
-
-|*spring.cloud.azure.eventhubs*.
-profile.environment.active-directory-endpoint
-| String
-| The Azure Active Directory endpoint to connect to.
-
-|*spring.cloud.azure.eventhubs*.resource.*
-| String
-| Metadata defining an Azure resource.
-
-|*spring.cloud.azure.eventhubs*.
-resource.resource-group
-| String
-| Name of the Azure resource group.
-
-|*spring.cloud.azure.eventhubs*.
-resource.resource-id
-| String
-| The id of the Azure resource group.
-
-|*spring.cloud.azure.eventhubs*.resource.region
-| String
-| The name of region.
-
-|*spring.cloud.azure.eventhubs*.client.transport-type
-| AmqpTransportType
-| The Transport type switches available for AMQP protocol.
-
-|*spring.cloud.azure.eventhubs*.retry.*
-| NA
-| Retry properties.
-
-|*spring.cloud.azure.eventhubs*.
-retry.backoff.*
-| NA
-| Backoff properties when a retry fails.
-
-|*spring.cloud.azure.eventhubs*.
-retry.backoff.delay
-| Duration
-| Amount of time to wait between retry attempts.
-
-|*spring.cloud.azure.eventhubs*.
-retry.backoff.max-delay
-| Duration
-| The maximum permissible amount of time between retry attempts.
-
-|*spring.cloud.azure.eventhubs*.
-retry.backoff.multiplier
-| Double
-| Multiplier used to calculate the next backoff delay.
-
-|*spring.cloud.azure.eventhubs*.
-retry.maxAttempts
-| Integer
-| The maximum number of attempts.
-
-|*spring.cloud.azure.eventhubs*.retry.timeout
-| Duration
-| Amount of time to wait until a timeout.
-
-|*spring.cloud.azure.eventhubs*.proxy.*
-| NA
-| Common proxy properties.
-
-|*spring.cloud.azure.eventhubs*.proxy.type
-| String
-| Type of the proxy.
-
-|*spring.cloud.azure.eventhubs*.proxy.hostname
-| String
-| The host of the proxy.
-
-|*spring.cloud.azure.eventhubs*.proxy.port
-| Integer
-| The port of the proxy.
-
-|*spring.cloud.azure.eventhubs*.
-proxy.authenticationType
-| String
-| Authentication type used against the proxy.
-
-|*spring.cloud.azure.eventhubs*.proxy.username
-| String
-| Username used to authenticate with the proxy.
-
-|*spring.cloud.azure.eventhubs*.proxy.password
-| String
-| Password used to authenticate with the proxy.
-|===
-
-===== Azure Event Hubs Client Configuration Options
-Below options are used to configure Azure Event Hubs SDK Client.
-
-.Client configurable properties of spring-cloud-azure-stream-binder-eventhubs
-[cols="<,<,<", options="header"]
-|===
-|Property | Type |Description
 
 |*spring.cloud.azure.eventhubs*.connection-string
 | String
@@ -259,101 +99,45 @@ is-shared-connection
 | Boolean
 | Whether to use the same connection for different Event Hub producer / consumer client.
 
-|*spring.cloud.azure.eventhubs*.producer.*
-| NA
-| Producer configuration options.
+|===
 
-|*spring.cloud.azure.eventhubs*.consumer.*
-| NA
-| Consumer configuration options.
+TIP: Common Azure Service SDK configuration options are configurable for the Spring Cloud Stream Event Hubs binder as well. The supported configuration options are introduced in link:configuration.adoc[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.`.
 
-|*spring.cloud.azure.eventhubs*.
-consumer.consumerGroup
-| NA
-| Name of the consumer group this consumer is associated with.
+===== Checkpoint Configuration Properties
+These properties are exposed via `com.azure.spring.cloud.autoconfigure.eventhubs.properties.AzureEventHubsProperties.Processor.BlobCheckpointStore`
+for the configuration of `BlobCheckpointStore`, which is the default implementation of `CheckpointStore` to use Storage Blobs for persisting partition ownership and checkpoint information.
 
-|*spring.cloud.azure.eventhubs*.consumer.prefetchCount
-| NA
-| The number of events the Event Hub consumer will actively receive and queue locally without regard to whether a receiving operation is currently active.
+.Checkpointing configurable properties of spring-cloud-azure-stream-binder-eventhubs
+[cols="<,<,<", options="header"]
+|===
+|Property | Type |Description
 
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.*
-| NA
-| Blob checkpoint store configuration options.
-
-|*spring.cloud.azure.eventhubs*.
-processor.trackLastEnqueuedEventProperties
-| Boolean
-|Whether the event processor should request information on the last enqueued event on its associated partition, and track that information as events are received.
-
-|*spring.cloud.azure.eventhubs*.
-processor.initialPartitionEventPosition
-| Map
-|The map containing the event position to use for each partition if a checkpoint for the partition does not exist in CheckpointStore.
-
-|*spring.cloud.azure.eventhubs*.
-processor.partitionOwnershipExpirationInterval
-| Duration
-|The time duration after which the ownership of partition expires if it's not renewed by the owning processor instance.
-
-|*spring.cloud.azure.eventhubs*.
-processor.batch. maxSize
-| Integer
-| The maximum number of events in a batch.
-
-|*spring.cloud.azure.eventhubs*.
-processor.batch. max-wait-time
-| Duration | The maximum time duration for one batch of the max size of message.
-
-|*spring.cloud.azure.eventhubs*.
-processor.loadBalancing.updateInterval
-| Duration
-| The interval of load balancing strategy updating.
-
-|*spring.cloud.azure.eventhubs*.
-processor.loadBalancing.strategy
-| String
-| The strategy used by event processor for load balancing the partition ownership to distribute the event processing work with other processor instances.
-
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.create-container-if-not-exists
+|*spring.cloud.azure.eventhubs.processor.checkpoint-store*.create-container-if-not-exists
 |Boolean
 |If allowed creating containers if not exists.
 
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.customer-provided-key
+|*spring.cloud.azure.eventhubs.processor.checkpoint-store*.account-name
 | String
-| Base64 encoded string of the encryption key.
+| Name for the storage account.
 
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.encryption-scope
+|*spring.cloud.azure.eventhubs.processor.checkpoint-store*.account-key
 | String
-| Encryption scope to encrypt blob contents on the server.
+| Storage account access key.
 
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.service-version
-| BlobServiceVersion
-|The versions of Azure Storage Blob supported by this client library.
-
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.blob-name
-| String
-| Storage blob name.
-
-|*spring.cloud.azure.eventhubs*.
-processor.checkpoint-store.container-name
+|*spring.cloud.azure.eventhubs.processor.checkpoint-store*.container-name
 | String
 | Storage container name.
 |===
 
-NOTE: For configuration of producer, consumer and processor, all the above common and client
-properties
-support to be configured individually by changing the origin prefix from *spring.cloud.azure.eventhubs* to *spring.cloud.azure.eventhubs.producer/consumer/processor*.
+TIP: Common Azure Service SDK configuration options are configurable for Storage Blob checkpoint store as well. The supported configuration options are introduced in link:configuration.adoc[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.processor.checkpoint-store`.
+
+NOTE: The default maximum connection pool size of the Storage Blob client is changed from `500` in version 3.x to `16` now, and the pending acquire queue size which is double of pool size is then `32` now. To override them, please set the property `spring.cloud.azure.eventhubs.processor.checkpoint-store.client.maximum-connection-pool-size`.
 
 ===== Azure Event Hubs Binding Configuration Options
 Below options are divided into four sections: Consumer Properties, Advanced Consumer
 Configurations, Producer PropertiesProducer Properties, and Advanced Producer Configurations.
 
+[#eventhubs-consumer-properties]
 ====== Consumer Properties
 
 .Consumer configurable properties of spring-cloud-azure-stream-binder-eventhubs
@@ -367,19 +151,19 @@ Configurations, Producer PropertiesProducer Properties, and Advanced Producer Co
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.checkpoint.count
 | Integer
-|Decides the amount of message for each partition to do one checkpoint.
+|Decides the amount of message for each partition to do one checkpoint. Will take effect only when `PARTITION_COUNT` checkpoint mode is used.
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.checkpoint.interval
 | Duration
-|Decides the time interval to do one checkpoint
+|Decides the time interval to do one checkpoint. Will take effect only when `TIME` checkpoint mode is used.
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.batch.max-size
 | Integer
-| The maximum number of events in a batch.
+| The maximum number of events in a batch. Required for the batch-consumer mode.
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.batch.max-wait-time
 | Duration
-| The maximum time duration for batch consuming.
+| The maximum time duration for batch consuming. Will take effect only when the batch-consumer mode is enabled and is optional.
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.load-balancing.update-interval
 | Duration
@@ -389,18 +173,25 @@ Configurations, Producer PropertiesProducer Properties, and Advanced Producer Co
 |LoadBalancingStrategy
 |The load balancing strategy.
 
+|*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.load-balancing.partition-ownership-expiration-interval
+|Duration
+|The time duration after which the ownership of partition expires.
+
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.track-last-enqueued-event-properties
 |Boolean
-| Whether the event processor should request information on the last enqueued event on its associated partition, and track that information as events are received.
+|Whether the event processor should request information on the last enqueued event on its associated partition, and track that information as events are received.
 
-|*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.partition-ownership-expiration-interval
-|Boolean
-| The expiration interval time for partition ownership
+|*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.prefetch-count
+|Integer
+|The count used by the consumer to control the number of events the Event Hub consumer will actively receive and queue locally.
+
+|*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.initial-partition-event-position
+|Map of `StartPositionProperties`
+|The map containing the event position to use for each partition if a checkpoint for the partition does not exist in checkpoint store. This map is keyed off of the partition id.
 |===
 
 ====== Advanced Consumer Configuration
-The configuration in the above first 2 sections(`Azure Common Configuration Options`, `Azure
-Event Hubs Client Configuration Options`) can be applied for each specific consumer by replacing the prefix of *spring.cloud.azure.eventhubs* with *spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.
+The above <<eventhubs-connection-configration, connection>>, <<Checkpoint Configuration Properties, checkpoint>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix *spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.*.
 
 ====== Producer Properties
 
@@ -411,16 +202,15 @@ Event Hubs Client Configuration Options`) can be applied for each specific consu
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.producer*.sync
 | boolean
-|The switch flag for sync of producer
+|The switch flag for sync of producer. If true, the producer will wait for a response after a send operation.
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.producer*.send-timeout
-| long
-| The timeout value for sending of producer
+| Duration
+|The amount of time to wait for a response after a send operation. Will take effect only when a sync producer is enabled.
 |===
 
 ====== Advanced Producer Configuration
-The configuration in the above first 2 sections(`Azure Common Configuration Options`, `Azure
-Event Hubs Client Configuration Options`) can be applied for each specific producer by replacing the prefix of *spring.cloud.azure.eventhubs* with *spring.cloud.stream.eventhubs.bindings.<binding-name>.producer*.
+The above <<eventhubs-connection-configration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix *spring.cloud.stream.eventhubs.bindings.<binding-name>.producer.*.
 
 ==== Basic Usage
 ===== Sending and Receiving messages from/to Event Hubs
@@ -586,7 +376,7 @@ spring:
           consume-in-0:
             consumer:
               batch:
-                max-batch-size: 10 # The default value is 10
+                max-batch-size: 10
                 max-wait-time: 1m # Optional, the default value is null
               checkpoint:
                 mode: BATCH # or MANUAL as needed
@@ -594,12 +384,22 @@ spring:
 
 Step2. Define supplier and consumer.
 
-For checkpointing mode as BATCH, you can use below code to send messages and consume in batches.
+For checkpointing mode as `BATCH`, you can use below code to send messages and consume in batches.
 [source,java]
 ----
 @Bean
-public Consumer<List<String>> consume() {
-    return list -> list.forEach(event -> LOGGER.info("New event received: '{}'",event));
+public Consumer<Message<List<String>>> consume() {
+    return message -> {
+            for (int i = 0; i < message.getPayload().size(); i++) {
+                LOGGER.info("New message received: '{}', partition key: {}, sequence number: {}, offset: {}, enqueued time: {}",
+                        message.getPayload().get(i),
+                        ((List<Object>) message.getHeaders().get(EventHubsHeaders.BATCH_CONVERTED_PARTITION_KEY)).get(i),
+                        ((List<Object>) message.getHeaders().get(EventHubsHeaders.BATCH_CONVERTED_SEQUENCE_NUMBER)).get(i),
+                        ((List<Object>) message.getHeaders().get(EventHubsHeaders.BATCH_CONVERTED_OFFSET)).get(i),
+                        ((List<Object>) message.getHeaders().get(EventHubsHeaders.BATCH_CONVERTED_ENQUEUED_TIME)).get(i));
+            }
+
+        };
 }
 
 @Bean
@@ -611,7 +411,7 @@ public Supplier<Message<String>> supply() {
 }
 ----
 
-For checkpointing mode as MANUAL, you can use below code to send messages and consume/checkpoint in batches.
+For checkpointing mode as `MANUAL`, you can use below code to send messages and consume/checkpoint in batches.
 [source,java]
 ----
 @Bean
@@ -675,6 +475,9 @@ public void producerError(Message<?> message) {
     LOGGER.error("Handling Producer ERROR: " + message);
 }
 ----
+
+===== Event Hubs message headers
+See the <<spring-integration-support.adoc#event-hubs-message-headers, Event Hubs message headers>> for more details.
 
 ==== Samples
 
@@ -981,7 +784,7 @@ of *spring.cloud.azure.servicebus* with *spring.cloud.stream.servicebus.bindings
 
 |*spring.cloud.stream.servicebus.bindings.<binding-name>.producer*.sync |boolean | Switch flag
 for sync of producer.
-|*spring.cloud.stream.servicebus.bindings.<binding-name>.producer*.send-timeout |long | Timeout
+|*spring.cloud.stream.servicebus.bindings.<binding-name>.producer*.send-timeout |Duration | Timeout
 value for sending of producer.
 
 |===
@@ -1201,8 +1004,8 @@ Please use this `sample` as a reference to learn more about how to use this bind
 - https://github.com/Azure-Samples/azure-spring-boot-samples/tree/main/servicebus/azure-spring-cloud-stream-binder-servicebus-queue[Service Bus Queue]
 
 
-### Set Service Bus message headers
-The following table illustrates how Spring message headers are mapped to Service Bus message headers and properties.
+*Example: Set Service Bus message headers*
+
 When create a message, developers can specify the header or property of a Service Bus message by
 below constants.
 
@@ -1221,6 +1024,7 @@ public ResponseEntity<String> sendMessage(@RequestParam String message) {
 }
 ----
 
+The following table illustrates how Spring message headers are mapped to Service Bus message headers and properties.
 For some Service Bus headers that can be mapped to multiple Spring header constants, the priority of different Spring headers is listed.
 
 .Mapping between Service Bus Headers and Spring Headers

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -35,7 +35,7 @@ To specify the load balancing strategy, properties of `spring.cloud.stream.event
 ===== Batch Consumer Support
 Azure Event Hubs Spring Cloud Stream Binder supports link:https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#_batch_consumers[Spring Cloud Stream Batch Consumer feature].
 
-To work with the batch-consumer mode, the property of `spring.cloud.stream.bindings.<binding-name>.consumer.batch-mode` should be set as `true`. When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of partition id, checkpointer and last enqueued properties, they are presented as a single value for the entire batch of events shares the same one.
+To work with the batch-consumer mode, the property of `spring.cloud.stream.bindings.<binding-name>.consumer.batch-mode` should be set as `true`. When enabled, an **org.springframework.messaging.Message** of which the payload is a list of batched events will be received and passed to the consumer function. Each message header is also converted as a list, of which the content is the associated header value parsed from each event. For the communal headers of partition id, checkpointer and last enqueued properties, they are presented as a single value for the entire batch of events shares the same one. See <<Event Hubs message headers, Event Hubs Message Headers>> for more details.
 
 NOTE: the checkpoint header only exists when **MANUAL** checkpoint mode is used.
 

--- a/docs/src/main/asciidoc/spring-integration-support.adoc
+++ b/docs/src/main/asciidoc/spring-integration-support.adoc
@@ -306,6 +306,55 @@ class Demo{
 }
 ----
 
+===== Event Hubs message headers
+
+The following table illustrates how Event Hubs message properties are mapped to Spring message headers. For Azure Event Hubs, message is called as `event`.
+
+.Mapping between Event Hubs properties and Spring Headers
+[cols="<,<,<,<", options="header"]
+|===
+|Event Hubs Event Properties | Spring Message Header Constants | Type | Description
+
+|Enqueued time
+|com.azure.spring.eventhubs.support.EventHubsHeaders#ENQUEUED_TIME
+|Instant
+|The instant, in UTC, of when the event was enqueued in the Event Hub partition.
+
+|Offset
+|com.azure.spring.eventhubs.support.EventHubsHeaders#OFFSET
+|Long
+|The offset of the event when it was received from the associated Event Hub partition.
+
+|Partition key
+|com.azure.spring.messaging.AzureHeaders#PARTITION_KEY
+|String
+|The partition hashing key if it was set when originally publishing the event.
+
+|Partition id
+|com.azure.spring.messaging.AzureHeaders#RAW_PARTITION_ID
+|String
+|The partition id of the Event Hub.
+
+|Sequence number
+|com.azure.spring.eventhubs.support.EventHubsHeaders#SEQUENCE_NUMBER
+|Long
+|The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.
+
+|Last enqueued event properties
+|com.azure.spring.eventhubs.support.EventHubsHeaders#LAST_ENQUEUED_EVENT_PROPERTIES
+|LastEnqueuedEventProperties
+|The properties of the last enqueued event in this partition.
+
+|NA
+|com.azure.spring.messaging.AzureHeaders#CHECKPOINTER
+|com.azure.spring.messaging.checkpoint.Checkpointer
+|The header for checkpoint the specific message.
+|===
+
+Users can parse the message headers for the related information of each event. To set a message header for the event, all customized headers will be put as an application property of an event, where the header is set as the property key. When events are received from Event Hubs, all application properties will be converted to the message header.
+
+NOTE: Message headers of partition key, enqueued time, offset and sequence number is not supported to be set manually.
+
 ==== Samples
 
 Please refer to link:https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0[azure-spring-boot-samples] for more details.

--- a/docs/src/main/asciidoc/spring-integration-support.adoc
+++ b/docs/src/main/asciidoc/spring-integration-support.adoc
@@ -310,7 +310,7 @@ class Demo{
 
 The following table illustrates how Event Hubs message properties are mapped to Spring message headers. For Azure Event Hubs, message is called as `event`.
 
-.Mapping between Event Hubs properties and Spring Headers
+.Mapping between Event Hubs Properties and Spring Headers
 [cols="<,<,<,<", options="header"]
 |===
 |Event Hubs Event Properties | Spring Message Header Constants | Type | Description


### PR DESCRIPTION
Update reference doc of spring cloud stream eventhubs:
1. add property of load-balancing
2. refactor configuration section
3. add warning of max pool size breaking change
4. ~add warning of batch consumer content type~ Done before
5. modify the consumer format to accept a message of list for the batch consumer mode
6. add section for message header.