### PR TITLE
update start-position change

### DIFF
--- a/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
+++ b/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
@@ -463,7 +463,10 @@ Changes for the child entries for following prefix, please refer the following t
 |*spring.cloud.stream.eventhub.bindings.<binding-name>.consumer*.checkpoint-mode |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.checkpoint.mode
 |*spring.cloud.stream.eventhub.bindings.<binding-name>.consumer*.checkpoint-count |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.checkpoint.count
 |*spring.cloud.stream.eventhub.bindings.<binding-name>.consumer*.checkpoint-interval |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.checkpoint.interval
+|*spring.cloud.stream.eventhub.bindings.<binding-name>.consumer*.start-position |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.initial-partition-event-position
 |===
+
+NOTE: The value type of the start position configuration is also changed. It is changed from an enum of `com.azure.spring.integration.core.api.StartPosition` to a `map` to specify the initial position for each partition. Thus, the key is the partition id, and the value is of an enum which accepts strings of `EARLIEST` and `LATEST`.
 
 For example, you should change from:
 
@@ -502,6 +505,8 @@ spring:
                     mode: [check-point-mode]
                     count: [checkpoint-count]
                     interval: [checkpoint-interval]
+                  initial-partition-event-position:
+                    <paritition-id>: EARLIEST
 ----
 
 ===== From azure-spring-cloud-stream-binder-servicebus-* to spring-cloud-azure-stream-binder-servicebus

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -183,9 +183,11 @@ Configurations, Producer Properties and Advanced Producer Configurations.
 |The count used by the consumer to control the number of events the Event Hub consumer will actively receive and queue locally.
 
 |*spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer*.initial-partition-event-position
-|Map of `StartPositionProperties`
+|Map with the key as the partition id, and values of `EARLIEST` and `LATEST`
 |The map containing the event position to use for each partition if a checkpoint for the partition does not exist in checkpoint store. This map is keyed off of the partition id.
 |===
+
+NOTE: The `initial-partition-event-position` configuration accepts a `map` to specify the initial position for each event hub. Thus, its key is the partition id, and the value is of an enum which accepts strings of `EARLIEST` and `LATEST`. For example, you can set it as `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.initial-partition-event-position.<partition-id>=EARLIEST`
 
 ====== Advanced Consumer Configuration
 The above <<eventhubs-connection-configration, connection>>, <<Checkpoint Configuration Properties, checkpoint>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.`.


### PR DESCRIPTION
Add introduction of the breaking change of initial position configuration in eventhubs binder migration guide.
Add example and introduction to initial position configuration in eventhubs binder ref doc.