### PR TITLE
add introduction about authentication changes

### DIFF
--- a/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
+++ b/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
@@ -1269,8 +1269,7 @@ spring:
           resource-group: ${RESOURCE_GROUP}
 ----
 
-You can also migrate to authenticate and authorize with Azure AD directly without making a detour to ARM. Security principals of the service principal and the manged identity are both supported, where the principal should
-be granted with necessary `Data` related roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
+You can also migrate to authenticate and authorize with Azure AD directly without making a detour to ARM. Make sure to grant the security principal necessary `Data` roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
 
 * With a service principal
 
@@ -1460,8 +1459,7 @@ spring:
           resource-group: ${SERVICEBUS_RESOURCE_GROUP}
 ----
 
-You can also migrate to authenticate and authorize with Azure AD directly without making a detour to ARM. Security principals of the service principal and the manged identity are both supported, where the principal should
-be granted with necessary `Data` related roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
+You can also migrate to authenticate and authorize with Azure AD directly without making a detour to ARM. Make sure to grant the security principal necessary `Data` roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
 
 * With a service principal
 

--- a/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
+++ b/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
@@ -1227,9 +1227,16 @@ spring:
                   inclusive: false
 ----
 
-To use the security principal to retrieve a connection string for authentication, taking service principal as example, configuration changes are listed as below:
+If you use other security principals instead of connection strings, in the legacy versions the application will firstly connect to Azure Resource Manager (ARM) with the provided security principal, and then
+retrieve the connection string of the specified namespace with ARM. In the end the application uses the retrieved connection string to authenticate to an Azure Service. In this way
+the provided security principal should be granted with the link:https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor[Contributor] role to retrieve of the associated Azure Service namespace.
 
-Legacy configuration:
+For Azure Spring Cloud 4.0, we provide two ways of leveraging security principals for authentication. One is the legacy usage, the principals are used to
+connect to ARM and then retrieve connection string as credentials, where the `Contributor` role is required.
+The other way leverages security principals to authenticate to Azure Active Directory and then connect to the Azure Service directly, in this case the `Contributor` role is not necessary anymore
+while other `Data` related roles are required for messaging operations, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
+
+For authentication based on ARM, taking service principal as example, configuration migration is listed as below, where the assigned role should not change:
 
 [source,yaml]
 ----
@@ -1237,14 +1244,14 @@ spring:
   cloud:
     azure:
       client-id: ${CLIENT_ID}
-        client-secret: ${CLIENT_SECRET}
+      client-secret: ${CLIENT_SECRET}
       tenant-id: ${TENANT_ID}
       resource-group: ${EVENTHUB_RESOURCE_GROUP}
       eventhub:
         namespace: ${EVENTHUB_NAMESPACE}
 ----
 
-Modern configuration:
+Modern configuration, properties for Azure subscription id and resource group are required:
 
 [source,yaml]
 ----
@@ -1263,8 +1270,10 @@ spring:
           resource-group: ${RESOURCE_GROUP}
 ----
 
-To use the security principal for authentication directly, taking service principals as example, users could use below configurations, where the principal should
-be granted with necessary `Data` related roles for messaging operations.
+For authentication based on Azure Active Directory, security principals of the service principal and the manged identity are both supported, where the principal should
+be granted with necessary `Data` related roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
+
+* Service principals
 
 [source,yaml]
 ----
@@ -1276,6 +1285,20 @@ spring:
         client-secret: ${CLIENT_SECRET}
       profile:
         tenant-id: ${TENANT_ID}
+      eventhubs:
+        namespace: ${EVENTHUB_NAMESPACE}
+----
+
+* Managed identities
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        managed-identity-enabled: true
+        client-id: ${AZURE_MANAGED_IDENTITY_CLIENT_ID} # Only needed when using a user-assigned managed identity
       eventhubs:
         namespace: ${EVENTHUB_NAMESPACE}
 ----
@@ -1341,7 +1364,6 @@ IMPORTANT: The binder type is combined from `servicebus-queue` and `servicebus-t
 NOTE: The concurrency property will replace maxConcurrentSessions when sessionsEnabled is `true` and maxConcurrentCalls when sessionsEnabled is `false`. Enabling auto-complete is equal to `RECORD` checkpoint mode, and oppositely the `MANUAL` mode.
 
 ====== Configuration migration examples
-To use the connection string for authentication and migrate the above mentioned properties, configuration changes are listed as below:
 
 Legacy configuration, taking queue as example:
 
@@ -1395,7 +1417,16 @@ spring:
               entity-type: queue #set as topic if needed
 ----
 
-To use the security principal to retrieve a connection string for authentication, taking service principal as example, configuration changes are listed as below:
+If you use other security principals instead of connection strings, in the legacy versions the application will firstly connect to Azure Resource Manager (ARM) with the provided security principal, and then
+retrieve the connection string of the specified namespace with ARM. In the end the application uses the retrieved connection string to authenticate to an Azure Service. In this way
+the provided security principal should be granted with the link:https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor[Contributor] role to retrieve of the associated Azure Service namespace.
+
+For Azure Spring Cloud 4.0, we provide two ways of leveraging security principals for authentication. One is the legacy usage, the principals are used to
+connect to ARM and then retrieve connection string as credentials, where the `Contributor` role is required.
+The other way leverages security principals to authenticate to Azure Active Directory and then connect to the Azure Service directly, in this case the `Contributor` role is not necessary anymore
+while other `Data` related roles are required for messaging operations, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
+
+For authentication based on ARM, taking service principal as example, configuration migration is listed as below, where the assigned role should not change:
 
 Legacy configuration:
 
@@ -1412,7 +1443,7 @@ spring:
         namespace: ${SERVICEBUS_NAMESPACE}
 ----
 
-Modern configuration:
+Modern configuration, properties for Azure subscription id and resource group are required:
 
 [source,yaml]
 ----
@@ -1431,8 +1462,10 @@ spring:
           resource-group: ${SERVICEBUS_RESOURCE_GROUP}
 ----
 
-To use the security principal for authentication directly, taking service principals as example, users could use below configurations, where the principal should
-be granted with necessary `Data` related roles for messaging operations.
+For authentication based on Azure Active Directory, security principals of the service principal and the manged identity are both supported, where the principal should
+be granted with necessary `Data` related roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
+
+* Service principals
 
 [source,yaml]
 ----
@@ -1444,6 +1477,20 @@ spring:
         client-secret: ${CLIENT_SECRET}
       profile:
         tenant-id: ${TENANT_ID}
+      servicebus:
+        namespace: ${SERVICEBUS_NAMESPACE}
+----
+
+* Managed identities
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        managed-identity-enabled: true
+        client-id: ${AZURE_MANAGED_IDENTITY_CLIENT_ID} # Only needed when using a user-assigned managed identity
       servicebus:
         namespace: ${SERVICEBUS_NAMESPACE}
 ----

--- a/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
+++ b/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
@@ -1161,7 +1161,10 @@ Changes for the child entries for following prefix, please refer the following t
 
 NOTE: The value type of the start position configuration is also changed. It's changed from an enum of `com.azure.spring.integration.core.api.StartPosition` to a `map` of `StartPositionProperties` for each partition. Thus, the key is the partition id, and the value is of `com.azure.spring.cloud.service.eventhubs.properties.StartPositionProperties` which includes properties of offset, sequence number, enqueued date time and whether inclusive.
 
-For example, you should change from:
+====== Configuration migration examples
+To use the connection string for authentication and migrate the above mentioned properties, configuration changes are listed as below:
+
+Legacy configuration:
 
 [source,yaml]
 ----
@@ -1187,7 +1190,7 @@ spring:
 
 ----
 
-to:
+Modern configuration:
 
 [source,yaml]
 ----
@@ -1222,6 +1225,59 @@ spring:
                   enqueued-date-time: 2022-01-12T13:32:47.650005Z
                 4:
                   inclusive: false
+----
+
+To use the security principal to retrieve a connection string for authentication, taking service principal as example, configuration changes are listed as below:
+
+Legacy configuration:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      client-id: ${CLIENT_ID}
+        client-secret: ${CLIENT_SECRET}
+      tenant-id: ${TENANT_ID}
+      resource-group: ${EVENTHUB_RESOURCE_GROUP}
+      eventhub:
+        namespace: ${EVENTHUB_NAMESPACE}
+----
+
+Modern configuration:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        client-id: ${CLIENT_ID}
+        client-secret: ${CLIENT_SECRET}
+      profile:
+        tenant-id: ${TENANT_ID}
+        subscription-id: ${SUBSCRIPTION_ID}
+      eventhubs:
+        namespace: ${EVENTHUB_NAMESPACE}
+        resource:
+          resource-group: ${RESOURCE_GROUP}
+----
+
+To use the security principal for authentication directly, taking service principals as example, users could use below configurations, where the principal should
+be granted with necessary `Data` related roles for messaging operations.
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        client-id: ${CLIENT_ID}
+        client-secret: ${CLIENT_SECRET}
+      profile:
+        tenant-id: ${TENANT_ID}
+      eventhubs:
+        namespace: ${EVENTHUB_NAMESPACE}
 ----
 
 [#api-spring-cloud-azure-stream-binder-eventhubs]
@@ -1284,7 +1340,10 @@ IMPORTANT: The binder type is combined from `servicebus-queue` and `servicebus-t
 
 NOTE: The concurrency property will replace maxConcurrentSessions when sessionsEnabled is `true` and maxConcurrentCalls when sessionsEnabled is `false`. Enabling auto-complete is equal to `RECORD` checkpoint mode, and oppositely the `MANUAL` mode.
 
-Taking queue as example, you should change from:
+====== Configuration migration examples
+To use the connection string for authentication and migrate the above mentioned properties, configuration changes are listed as below:
+
+Legacy configuration, taking queue as example:
 
 [source,yaml]
 ----
@@ -1309,6 +1368,8 @@ spring:
                 checkpoint-mode: MANUAL
 ----
 
+Modern configuration:
+
 [source,yaml]
 ----
 spring:
@@ -1331,7 +1392,60 @@ spring:
               auto-complete: false
           supply-out-0:
             producer:
-              entity-type: queue #set topic if needed
+              entity-type: queue #set as topic if needed
+----
+
+To use the security principal to retrieve a connection string for authentication, taking service principal as example, configuration changes are listed as below:
+
+Legacy configuration:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      client-id: ${CLIENT_ID}
+      client-secret: ${CLIENT_SECRET}
+      tenant-id: ${TENANT_ID}
+      resource-group: ${SERVICEBUS_RESOURCE_GROUP}
+      servicebus:
+        namespace: ${SERVICEBUS_NAMESPACE}
+----
+
+Modern configuration:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        client-id: ${CLIENT_ID}
+        client-secret: ${CLIENT_SECRET}
+      profile:
+        tenant-id: ${TENANT_ID}
+        subscription-id: ${SUBSCRIPTION_ID}
+      servicebus:
+        namespace: ${SERVICEBUS_NAMESPACE}
+        resource:
+          resource-group: ${SERVICEBUS_RESOURCE_GROUP}
+----
+
+To use the security principal for authentication directly, taking service principals as example, users could use below configurations, where the principal should
+be granted with necessary `Data` related roles for messaging operations.
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        client-id: ${CLIENT_ID}
+        client-secret: ${CLIENT_SECRET}
+      profile:
+        tenant-id: ${TENANT_ID}
+      servicebus:
+        namespace: ${SERVICEBUS_NAMESPACE}
 ----
 
 [#api-spring-cloud-azure-stream-binder-servicebus]

--- a/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
+++ b/docs/src/main/asciidoc/_migration-guide-for-4.0.adoc
@@ -1227,13 +1227,12 @@ spring:
                   inclusive: false
 ----
 
-If you use other security principals instead of connection strings, in the legacy versions the application will firstly connect to Azure Resource Manager (ARM) with the provided security principal, and then
-retrieve the connection string of the specified namespace with ARM. In the end the application uses the retrieved connection string to authenticate to an Azure Service. In this way
-the provided security principal should be granted with the link:https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor[Contributor] role to retrieve of the associated Azure Service namespace.
+If you use security principals instead of connection strings, in versions before 4.0 the application will firstly connect to Azure Resource Manager (ARM) with the provided security principal, and then
+retrieve the connection string of the specified namespace with ARM. In the end the application uses the retrieved connection string to connect to Azure Event Hubs. In this way
+the provided security principal should be granted with the link:https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor[Contributor] role to retrieve of the associated Azure Event Hubs namespace.
 
-For Azure Spring Cloud 4.0, we provide two ways of leveraging security principals for authentication. One is the legacy usage, the principals are used to
-connect to ARM and then retrieve connection string as credentials, where the `Contributor` role is required.
-The other way leverages security principals to authenticate to Azure Active Directory and then connect to the Azure Service directly, in this case the `Contributor` role is not necessary anymore
+For Azure Spring Cloud 4.0, we provide two ways of leveraging security principals for authentication. One is still using the principals to connect to ARM and retrieve the connection strings where the `Contributor` role is required for the principals.
+The other leverages security principals to authenticate to Azure Active Directory (Azure AD) and then connect to Azure Event Hubs directly, in this case the `Contributor` role is not necessary anymore
 while other `Data` related roles are required for messaging operations, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
 
 For authentication based on ARM, taking service principal as example, configuration migration is listed as below, where the assigned role should not change:
@@ -1270,10 +1269,10 @@ spring:
           resource-group: ${RESOURCE_GROUP}
 ----
 
-For authentication based on Azure Active Directory, security principals of the service principal and the manged identity are both supported, where the principal should
+You can also migrate to authenticate and authorize with Azure AD directly without making a detour to ARM. Security principals of the service principal and the manged identity are both supported, where the principal should
 be granted with necessary `Data` related roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
 
-* Service principals
+* With a service principal
 
 [source,yaml]
 ----
@@ -1289,7 +1288,7 @@ spring:
         namespace: ${EVENTHUB_NAMESPACE}
 ----
 
-* Managed identities
+* With a managed identity
 
 [source,yaml]
 ----
@@ -1417,13 +1416,12 @@ spring:
               entity-type: queue #set as topic if needed
 ----
 
-If you use other security principals instead of connection strings, in the legacy versions the application will firstly connect to Azure Resource Manager (ARM) with the provided security principal, and then
-retrieve the connection string of the specified namespace with ARM. In the end the application uses the retrieved connection string to authenticate to an Azure Service. In this way
-the provided security principal should be granted with the link:https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor[Contributor] role to retrieve of the associated Azure Service namespace.
+If you use security principals instead of connection strings, in versions before 4.0 the application will firstly connect to Azure Resource Manager (ARM) with the provided security principal, and then
+retrieve the connection string of the specified namespace with ARM. In the end the application uses the retrieved connection string to connect to Azure Service Bus. In this way
+the provided security principal should be granted with the link:https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor[Contributor] role to retrieve of the associated Azure Service Bus namespace.
 
-For Azure Spring Cloud 4.0, we provide two ways of leveraging security principals for authentication. One is the legacy usage, the principals are used to
-connect to ARM and then retrieve connection string as credentials, where the `Contributor` role is required.
-The other way leverages security principals to authenticate to Azure Active Directory and then connect to the Azure Service directly, in this case the `Contributor` role is not necessary anymore
+For Azure Spring Cloud 4.0, we provide two ways of leveraging security principals for authentication. One is still using the principals to connect to ARM and retrieve the connection strings where the `Contributor` role is required for the principals.
+The other leverages security principals to authenticate to Azure Active Directory (Azure AD) and then connect to the Azure Service Bus directly, in this case the `Contributor` role is not necessary anymore
 while other `Data` related roles are required for messaging operations, please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the security principal has been granted the sufficient permission to access the Azure resource.
 
 For authentication based on ARM, taking service principal as example, configuration migration is listed as below, where the assigned role should not change:
@@ -1462,10 +1460,10 @@ spring:
           resource-group: ${SERVICEBUS_RESOURCE_GROUP}
 ----
 
-For authentication based on Azure Active Directory, security principals of the service principal and the manged identity are both supported, where the principal should
+You can also migrate to authenticate and authorize with Azure AD directly without making a detour to ARM. Security principals of the service principal and the manged identity are both supported, where the principal should
 be granted with necessary `Data` related roles for messaging operations. The configuration examples of the service principal and the manged identity are listed as below:
 
-* Service principals
+* With a service principal
 
 [source,yaml]
 ----
@@ -1481,7 +1479,7 @@ spring:
         namespace: ${SERVICEBUS_NAMESPACE}
 ----
 
-* Managed identities
+* With a managed identity
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/resource-manager.adoc
+++ b/docs/src/main/asciidoc/resource-manager.adoc
@@ -1,3 +1,4 @@
+[#spring-cloud-azure-resourcemanager]
 == Resource Manager
 
 Azure Resource Manager (ARM) is the deployment and management service for Azure. It provides a management layer that enables you to create, update, and delete resources in your Azure account. Spring Cloud Azure Resourcemanger can help provision resources or retrieve resource metadata. 
@@ -32,11 +33,34 @@ NOTE: If you choose to use a security principal to authenticate and authorize wi
 |*spring.cloud.azure.profile*.environment.active-directory-endpoint |The Azure Active Directory endpoint to connect to for authentication.
 |*spring.cloud.azure.profile*.subscription-id |Subscription id to use when connecting to Azure resources.
 |*spring.cloud.azure.profile*.tenant-id |Tenant id for Azure resources.
+|*spring.cloud.azure.<azure-service>*.namespace |The namespace of the Azure service to provision resources with.
+|*spring.cloud.azure.<azure-service>*.resource.resource-group |The resource group holding an Azure service resource.
 |===
 
+[#resource-manager-basic-usage]
 === Basic Usage
 
-Spring Cloud Azure Resourcemanger can work together with specific Spring Cloud Azure starters to retrieve connection information, such as connection strings, to connect to Azure services. It can also together with `spring-cloud-azure-starter` and third-party libraries to retrieve metadata like username/password, to complete authentication, such as: <<Kafka Support>>, <<Redis Support>>.
+Spring Cloud Azure Resource Manager can work together with specific Spring Cloud Azure starters to retrieve connection information, such as connection strings, to connect to Azure services. It can also together with `spring-cloud-azure-starter` and third-party libraries to retrieve metadata like username/password, to complete authentication, such as: <<Kafka Support>>, <<Redis Support>>.
+
+For example, to retrieve the connection string of an Azure Service, developers can use a service principal as the credential to authenticate and retrieve the connection string. The configuration is listed as below. The provided service principal should
+be assigned a role of `Contributor` of the associated namespace at least. Please refer to link:index.html#authorize-access-with-azure-active-directory[Authorize access with Azure AD] to make sure the principal has been granted the sufficient permission to access the Azure resource.
+
+[source,yaml]
+----
+spring:
+  cloud:
+    azure:
+      credential:
+        client-id: ${CLIENT_ID}
+        client-secret: ${CLIENT_SECRET}
+      profile:
+        tenant-id: ${TENANT_ID}
+        subscription-id: ${SUBSCRIPTION_ID}
+      <azure-service>:
+        namespace: ${SERVICEBUS_NAMESPACE}
+        resource:
+          resource-group: ${RESOURCE_GROUP}
+----
 
 === Samples
 

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -103,6 +103,8 @@ NOTE: If you choose to use a security principal to authenticate and authorize wi
 
 TIP: Common Azure Service SDK configuration options are configurable for the Spring Cloud Azure Stream Event Hubs binder as well. The supported configuration options are introduced in link:configuration.html[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.eventhubs.`.
 
+The binder also supports link:index.html#spring-cloud-azure-resourcemanager[Spring Could Azure Resource Manager] by default. To learn about how to retrieve the connection string with security principals that are not granted with `Data` related roles, please refer to the link:index.html#resource-manager-basic-usage[resource manager example] for details.
+
 ===== Checkpoint Configuration Properties
 This section contains the configuration options for the Storage Blobs service, which is used for persisting partition ownership and checkpoint information.
 
@@ -716,6 +718,8 @@ NOTE: If you choose to use a security principal to authenticate and authorize wi
 
 TIP: Common Azure Service SDK configuration options are configurable for the Spring Cloud Azure Stream Service Bus binder as well. The supported configuration options are introduced in link:configuration.html[the Configuration page], and could be configured with either the unified prefix `spring.cloud.azure.` or the prefix of `spring.cloud.azure.servicebus.`.
 
+The binder also supports link:index.html#spring-cloud-azure-resourcemanager[Spring Could Azure Resource Manager] by default. To learn about how to retrieve the connection string with security principals that are not granted with `Data` related roles, please refer to the link:index.html#resource-manager-basic-usage[resource manager example] for details.
+
 ===== Azure Service Bus Binding Configuration Properties
 Below options are divided into four sections: Consumer Properties, Advanced Consumer
 Configurations, Producer Properties and Advanced Producer Configurations.
@@ -827,7 +831,7 @@ spring:
         bindings:
           consume-in-0:
             consumer:
-              checkpoint-mode: MANUAL
+              auto-complete: false
           supply-out-0:
             producer:
               entity-type: queue # set as "topic" if you use Service Bus Topic
@@ -860,7 +864,7 @@ spring:
         bindings:
           consume-in-0:
             consumer:
-              checkpoint-mode: MANUAL
+              auto-complete: false
           supply-out-0:
             producer:
               entity-type: queue # set as "topic" if you use Service Bus Topic
@@ -891,7 +895,7 @@ spring:
         bindings:
           consume-in-0:
             consumer:
-              checkpoint-mode: MANUAL
+              auto-complete: false
           supply-out-0:
             producer:
               entity-type: queue # set as "topic" if you use Service Bus Topic
@@ -1067,13 +1071,13 @@ spring:
         bindings:
           consume1-in-0:
             consumer:
-              checkpoint-mode: MANUAL
+              auto-complete: false
           supply1-out-0:
             producer:
               entity-type: topic
           consume2-in-0:
             consumer:
-              checkpoint-mode: MANUAL
+              auto-complete: false
           supply2-out-0:
             producer:
               entity-type: queue

--- a/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-support.adoc
@@ -66,7 +66,7 @@ Alternatively, you can also use the Spring Cloud Azure Stream Event Hubs Starter
 
 The binder provides the following 3 parts of configuration options:
 
-[#eventhubs-connection-configration]
+[#eventhubs-connection-configuration]
 ===== Connection Configuration Properties
 
 This section contains the configuration options used for connecting to Azure Event Hubs.
@@ -216,7 +216,7 @@ spring:
 ----
 
 ====== Advanced Consumer Configuration
-The above <<eventhubs-connection-configration, connection>>, <<Checkpoint Configuration Properties, checkpoint>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.`.
+The above <<eventhubs-connection-configuration, connection>>, <<Checkpoint Configuration Properties, checkpoint>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.consumer.`.
 
 ====== Producer Properties
 
@@ -237,7 +237,7 @@ These properties are exposed via `EventHubsProducerProperties`.
 |===
 
 ====== Advanced Producer Configuration
-The above <<eventhubs-connection-configration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.producer.`.
+The above <<eventhubs-connection-configuration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix `spring.cloud.stream.eventhubs.bindings.<binding-name>.producer.`.
 
 ==== Basic Usage
 ===== Sending and Receiving Messages from/to Event Hubs
@@ -686,7 +686,7 @@ Alternatively, you can also use the Spring Cloud Azure Stream Service Bus Starte
 ==== Configuration
 The binder provides the following 2 parts of configuration options:
 
-[#servicebus-connection-configration]
+[#servicebus-connection-configuration]
 ===== Connection Configuration Properties
 
 This section contains the configuration options used for connecting to Azure Service Bus.
@@ -782,7 +782,7 @@ to enable developers to settle messages manually.
 |===
 
 ====== Advanced Consumer Configuration
-The above <<servicebus-connection-configration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix `spring.cloud.stream.servicebus.bindings.<binding-name>.consumer.`.
+The above <<servicebus-connection-configuration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder consumer, which can be configured with the prefix `spring.cloud.stream.servicebus.bindings.<binding-name>.consumer.`.
 
 ====== Producer Properties
 
@@ -803,7 +803,7 @@ value for sending of producer.
 IMPORTANT: When using the binding producer, property of `spring.cloud.stream.servicebus.bindings.<binding-name>.producer.entity-type` is required to be configured.
 
 ====== Advanced Producer Configuration
-The above <<servicebus-connection-configration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix `spring.cloud.stream.servicebus.bindings.<binding-name>.producer.`.
+The above <<servicebus-connection-configuration, connection>> and <<Configuration.adoc#configuration, common Azure SDK client>> configuration are supported to be customized for each binder producer, which can be configured with the prefix `spring.cloud.stream.servicebus.bindings.<binding-name>.producer.`.
 
 ==== Basic Usage
 ===== Sending and Receiving Messages from/to Service Bus

--- a/docs/src/main/asciidoc/spring-integration-support.adoc
+++ b/docs/src/main/asciidoc/spring-integration-support.adoc
@@ -55,7 +55,6 @@ To specify the batch consuming strategy, developers can use `EventHubsContainerP
 
 This starter provides the following 3 parts of configuration options:
 
-[#eventhubs-connection-configration]
 ===== Connection Configuration Properties
 This section contains the configuration options used for connecting to Azure Event Hubs.
 
@@ -449,7 +448,6 @@ Please refer to Javadoc for details.
 
 This starter provides the following 2 parts of configuration options:
 
-[#servicebus-connection-configration]
 ===== Connection Configuration Properties
 
 This section contains the configuration options used for connecting to Azure Service Bus.
@@ -801,7 +799,6 @@ Azure Queue Storage is a service for storing large numbers of messages. You acce
 
 This starter provides the following configuration options:
 
-[#storage-queue-connection-configration]
 ===== Connection Configuration Properties
 This section contains the configuration options used for connecting to Azure Storage Queue.
 


### PR DESCRIPTION
This pr is aimed to update the migration guide and reference doc of eh and sb binder,  to add the introduction about how to use security principals to retrieve connection strings.