### PR TITLE
Update github actions to support unreleased libraries

### DIFF
--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -6,11 +6,6 @@ on:
     - main
     - docs
     - 4.*
-  pull_request:
-    branches:
-    - main
-    - docs
-    - 4.*
     # paths:
     # - 'docs/**'
   # release:
@@ -89,8 +84,6 @@ jobs:
           ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.release.tag_name }} --destination . --build
         elif [[ -n "${{ github.event.inputs.committish }}" ]] && [[ "${{ github.event.inputs.committish }}" != "main" ]] ; then
             ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.inputs.committish }} --destination . --build
-        elif [[ -n "${{ github.event.pull_request.base.ref }}" ]] ; then 
-          ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.pull_request.base.ref }} --destination .  --build
-        else 
-          ./docs/src/main/asciidoc/ghpages.sh  --build
+        else
+          ./docs/src/main/asciidoc/ghpages.sh --build
         fi

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -21,6 +21,24 @@ jobs:
   updateDocs:
     runs-on: ubuntu-20.04
     steps:
+    - run: | 
+          git init azure-sdk-for-java
+          cd azure-sdk-for-java
+          git remote add origin https://github.com/Azure/azure-sdk-for-java.git
+          git config core.sparsecheckout true
+          echo "sdk/spring" >> .git/info/sparse-checkout
+          echo "eng" >> .git/info/sparse-checkout
+          echo "sdk/keyvault" >> .git/info/sparse-checkout
+          echo "sdk/boms" >> .git/info/sparse-checkout
+          git pull --depth=1 origin feature/azure-spring-cloud-4.0
+          mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
+            -Dcheckstyle.skip=true \
+            -ntp \
+            -Dspotbugs.skip=true \
+            -Drevapi.skip=true -Djacoco.skip=true \
+            -Dparallel-test-playback \
+            -Pdev \
+            -f sdk/spring/pom.xml
     - name: Get current date
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -6,6 +6,11 @@ on:
     - main
     - docs
     - 4.*
+  pull_request:
+    branches:
+    - main
+    - docs
+    - 4.*
     # paths:
     # - 'docs/**'
   # release:
@@ -84,6 +89,8 @@ jobs:
           ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.release.tag_name }} --destination . --build
         elif [[ -n "${{ github.event.inputs.committish }}" ]] && [[ "${{ github.event.inputs.committish }}" != "main" ]] ; then
             ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.inputs.committish }} --destination . --build
-        else
-          ./docs/src/main/asciidoc/ghpages.sh --build
+        elif [[ -n "${{ github.event.pull_request.base.ref }}" ]] ; then 
+          ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.pull_request.base.ref }} --destination .  --build
+        else 
+          ./docs/src/main/asciidoc/ghpages.sh  --build
         fi

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.azure.spring</groupId>
     <artifactId>spring-cloud-azure-aggregator</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.0-beta.1</version>
     <packaging>pom</packaging>
     <name>Spring Cloud Azure</name>
     <description>Spring Cloud Azure</description>
@@ -39,8 +39,8 @@
         <!-- <javax.activation.version>1.2.0</javax.activation.version> -->
         <spring-cloud-commons.version>3.1.1</spring-cloud-commons.version>
         <!-- "version.spring.cloud.azure" is used to update "_configprops.adoc".
-         To make GitHub Actions pass, use the latest released version instead of current developing version.-->
-        <version.spring.cloud.azure>4.0.0</version.spring.cloud.azure>
+         -->
+        <version.spring.cloud.azure>4.1.0-beta.1</version.spring.cloud.azure>
         <spring-javaformat.version>0.0.29</spring-javaformat.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
1. Update workflow, build and install packages manually instead of downloading from maven central.
2. Update versions in pom.xml