### PR TITLE
Update workflow add folder sdk/aot

### DIFF
--- a/.github/workflows/brokenLinkCheck.yml
+++ b/.github/workflows/brokenLinkCheck.yml
@@ -27,6 +27,7 @@ jobs:
           echo "eng" >> .git/info/sparse-checkout
           echo "sdk/keyvault" >> .git/info/sparse-checkout
           echo "sdk/boms" >> .git/info/sparse-checkout
+          echo "sdk/aot" >> .git/info/sparse-checkout
           git pull --depth=1 origin main
           mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
             -Dcheckstyle.skip=true \

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -30,6 +30,7 @@ jobs:
           echo "eng" >> .git/info/sparse-checkout
           echo "sdk/keyvault" >> .git/info/sparse-checkout
           echo "sdk/boms" >> .git/info/sparse-checkout
+          echo "sdk/aot" >> .git/info/sparse-checkout
           git pull --depth=1 origin main
           mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
             -Dcheckstyle.skip=true \


### PR DESCRIPTION
In this [pom.xml](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/spring/pom.xml#L198), libraries under folder `sdk/aot` are imported, so we need to add the folder in ci workflow configuration file.