### PR TITLE
Exclude properties of Azure AD B2C from Azure AD properties table

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -135,7 +135,7 @@
                 <configuration>
                   <arguments>
                     <argument>${project.basedir}/src/main/asciidoc/_configprops_aad.adoc</argument>
-                    <argument>spring.cloud.azure.active-directory.*</argument>
+                    <argument>(?!spring.cloud.azure.active-directory.b2c.*)(spring.cloud.azure.active-directory.*)</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/docs/src/main/asciidoc/redis-support.adoc
+++ b/docs/src/main/asciidoc/redis-support.adoc
@@ -29,7 +29,7 @@ NOTE: If you choose to use a security principal to authenticate and authorize wi
 [cols="4*", options="header"]
 |===
 |Property |Description |Default Value | Required
-|*spring.cloud.azure.redis*.enabled |Azure Cache for Redis instance name.|true | No
+|*spring.cloud.azure.redis*.enabled |A value that indicates whether the Azure Cache for Redis is enabled.|true | No
 |*spring.cloud.azure.redis*.name |Azure Cache for Redis instance name.| |Yes
 |*spring.cloud.azure.redis*.resource.resource-group |The resource group of Azure Cache for Redis.||Yes
 |*spring.cloud.azure*.profile.subscription-id| The subscription id. ||Yes

--- a/docs/src/main/asciidoc/spring-security-support.adoc
+++ b/docs/src/main/asciidoc/spring-security-support.adoc
@@ -191,7 +191,7 @@ image:https://user-images.githubusercontent.com/13167207/149295662-072ca3d5-f9e1
 spring:
   cloud:
     azure:
-      active-directory
+      active-directory:
         redirect-uri-template: ${REDIRECT-URI-TEMPLATE}
 ----
 


### PR DESCRIPTION
As title.
In the [appendix page](https://microsoft.github.io/spring-cloud-azure/current/reference/html/appendix.html#_azure_active_directory_properties) of the reference documentation, Azure AD B2C properties should not be included in the properties table of Azure AD.