### PR TITLE
Update README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 [![Broken Link Checker](https://github.com/microsoft/spring-cloud-azure/actions/workflows/brokenLinkCheck.yml/badge.svg)](https://github.com/microsoft/spring-cloud-azure/actions/workflows/brokenLinkCheck.yml) [![GH Pages Broken Link Checker](https://github.com/microsoft/spring-cloud-azure/actions/workflows/scheduleCurrentLinkCheck.yaml/badge.svg)](https://github.com/microsoft/spring-cloud-azure/actions/workflows/scheduleCurrentLinkCheck.yaml) [![Update Docs](https://github.com/microsoft/spring-cloud-azure/actions/workflows/updateDocs.yaml/badge.svg)](https://github.com/microsoft/spring-cloud-azure/actions/workflows/updateDocs.yaml) [![pages-build-deployment](https://github.com/microsoft/spring-cloud-azure/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/microsoft/spring-cloud-azure/actions/workflows/pages/pages-build-deployment)
 
-The source code of Spring Cloud Azure artifacts are moved to [Azure/azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring) repository.
 
-This repo is only used to manage the [Reference Doc](https://microsoft.github.io/spring-cloud-azure).
+Spring Cloud Azure is an open-source project that provides seamless Spring integration with Azure services.
+
+
+ - Reference doc: [Spring Cloud Azure - Reference Documentation](https://microsoft.github.io/spring-cloud-azure).
+ - Samples: [Azure-Samples/azure-spring-boot-samples](https://github.com/Azure-Samples/azure-spring-boot-samples).
+ - Source code: [Azure/azure-sdk-for-java/sdk/spring](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring).


### PR DESCRIPTION
This repo is high possibility appeared in the result when searching "Azure Spring Cloud" by searching engine. 

We should put more information about "Spring on Azure" project instead of just let customer know that this repo is used to manage the reference doc.

So. I add these items in the README.md:
1. Brief introduction of "Spring on Azure" introduction.
2. Links to reference doc / samples / source code.


And I already updated the "About" fragment in current repo:
![image](https://user-images.githubusercontent.com/13167207/167360014-d9f55243-a33d-4544-b709-e4c176b1897e.png)
