### PR TITLE
Fix pipeline broken link checker error

### DIFF
--- a/.github/workflows/brokenLinkCheck.yml
+++ b/.github/workflows/brokenLinkCheck.yml
@@ -44,13 +44,13 @@ jobs:
         run: |
           ./mvnw clean install -P docs -pl docs -DskipTests
 
-      - name: Html Link Checker
+      - name: Check link in generated html files
         id: html-link-report
         uses: peter-evans/link-checker@v1
         with:
-          args: -d --document-root ./docs/target/generated-docs -r -x "my|localhost|127.0.0.1"
+          args: -d --document-root ./docs/target/generated-docs -r -x "https://my.custom.endpoint.com:55300|localhost"
 
-      - name: Link version replacement
+      - name: Replace bata to main in html-link-report result
         run: |
           if [ -d "link-checker/" ] ; then
              cd link-checker
@@ -59,11 +59,11 @@ jobs:
              sudo mv out.md ../
           fi
 
-      - name: Markdown Links Check
+      - name: Check link in all markdown files
         id: markdown-link-report
         uses: peter-evans/link-checker@v1
         with:
-          args: -d . -v -r -x "my|localhost|127.0.0.1" *.md
+          args: -d . -v -r -x "https://my.custom.endpoint.com:55300|localhost" *.md
 
       - name: Fail if there were link errors
         run: exit ${{ steps.markdown-link-report.outputs.exit_code }}

--- a/.github/workflows/brokenLinkCheck.yml
+++ b/.github/workflows/brokenLinkCheck.yml
@@ -52,15 +52,18 @@ jobs:
 
       - name: Link version replacement
         run: |
-          cd link-checker
-          sudo sed -i 's/spring-cloud-azure_*.*.*-beta.[0-9]/main/g' *
-          sudo sed -i 's/```/ /g' *
+          if [ -d "link-checker/" ] ; then
+             cd link-checker
+             sudo sed -i 's/spring-cloud-azure_*.*.*-beta.[0-9]/main/g' *
+             sudo sed -i 's/```/ /g' *
+             sudo mv out.md ../
+          fi
 
       - name: Markdown Links Check
         id: markdown-link-report
         uses: peter-evans/link-checker@v1
         with:
-          args: -d --document-root ./link-checker -v -r *.md
+          args: -d . -v -r -x "my|localhost|127.0.0.1" *.md
 
       - name: Fail if there were link errors
         run: exit ${{ steps.markdown-link-report.outputs.exit_code }}

--- a/.github/workflows/scheduleCurrentLinkCheck.yaml
+++ b/.github/workflows/scheduleCurrentLinkCheck.yaml
@@ -19,5 +19,5 @@ jobs:
         uses: ScholliYT/Broken-Links-Crawler-Action@v3
         with:
           website_url: 'https://microsoft.github.io/spring-cloud-azure/'
-          exclude_url_prefix: 'http://localhost:,http://HOST_NAME:,http://127.0.0.1:,https://my.'
+          exclude_url_prefix: 'http://localhost:,http://HOST_NAME:,https://my.custom.endpoint.com:55300'
           verbose: 'true'


### PR DESCRIPTION
GitHub action file: https://github.com/microsoft/spring-cloud-azure/blob/main/.github/workflows/brokenLinkCheck.yml

In step `Link version replacement`, when there is a broken link, it will be output to link-checker/out.md. When there is no broken link, it is not processed in the current pipeline.