### PR TITLE
Add a branch condition to trigger version docs generated

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -6,6 +6,7 @@ on:
     - main
     - docs
     - 4.*
+    - feature/spring-boot-3
   # paths:
     # - 'docs/**'
   # release:


### PR DESCRIPTION
The expected result is the special version doc generated from branch `feature/spring-boot-3`.