### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+      run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v2
     - run: |
         git config user.name github-actions

--- a/.github/workflows/update-properties-table-in-ms-docs.yaml
+++ b/.github/workflows/update-properties-table-in-ms-docs.yaml
@@ -45,8 +45,8 @@ jobs:
         id: get_project_version_and_branch_name
         run: |
           project_version=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
-          echo ::set-output name=branch_name::spring-cloud-azure_${project_version%-*}
-          echo ::set-output name=project_version::${project_version%-*}
+          echo branch_name=spring-cloud-azure_${project_version%-*} >> $GITHUB_OUTPUT
+          echo project_version=${project_version%-*} >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
         name: Checkout MicrosoftDocs/azure-dev-docs-pr
@@ -65,7 +65,7 @@ jobs:
           git config --global user.name github-actions
           git remote add ${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }} https://github.com/${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }}/azure-dev-docs-pr.git
           git fetch ${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }}
-          echo ::set-output name=topic_branch_exists::$(git ls-remote --heads ${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }} ${{ steps.get_project_version_and_branch_name.outputs.branch_name }} | wc -l)
+          echo topic_branch_exists=$(git ls-remote --heads ${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }} ${{ steps.get_project_version_and_branch_name.outputs.branch_name }} | wc -l) >> $GITHUB_OUTPUT
 
       - name: Commit files changes to topic branch
         id: commit_files_changes_to_topic_branch
@@ -80,7 +80,7 @@ jobs:
           fi
           cp -f ../spring-cloud-azure-markdown-appdendix-generator/src/main/asciidoc/configuration-*.md articles/java/spring-framework/includes/spring-cloud-azure
           if [[ -n "$(git status -s)" ]] ;then
-            echo '::set-output name=added_a_commit_in_topic_branch::true'
+          echo "added_a_commit_in_topic_branch=true" >> $GITHUB_OUTPUT
             git add ./articles/java/spring-framework/includes/spring-cloud-azure/configuration-*.md
             git commit -m "Update the configuration properties for Spring Cloud Azure: ${{ steps.get_project_version_and_branch_name.outputs.project_version }}. This commit is created by GitHub Action: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
             git push "https://${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }}:${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_ACCESS_TOKEN }}@github.com/${{ secrets.UPDATE_PROPERTIES_TABLE_IN_MS_DOCS_GITHUB_USERNAME }}/azure-dev-docs-pr.git"


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

Resolve #1049 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```
